### PR TITLE
[16.0][FIX] account_banking_ach_direct_debit_portal: Add missing system parameter to data

### DIFF
--- a/account_banking_ach_direct_debit_portal/__manifest__.py
+++ b/account_banking_ach_direct_debit_portal/__manifest__.py
@@ -11,6 +11,7 @@
     "category": "Banking addons",
     "depends": ["account_banking_ach_direct_debit", "account_payment"],
     "data": [
+        "data/res_config_settings_data.xml",
         "security/portal_user_access.xml",
         "views/searchbar.xml",
         "views/autopay_rules_templates.xml",

--- a/account_banking_ach_direct_debit_portal/data/res_config_settings_data.xml
+++ b/account_banking_ach_direct_debit_portal/data/res_config_settings_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record
+        id="default_credit_card_surcharge"
+        model="ir.config_parameter"
+        forcecreate="0"
+    >
+        <field
+            name="key"
+        >account_banking_ach_direct_debit_portal.credit_card_surcharge</field>
+        <field name="value">3.0</field>
+    </record>
+</odoo>


### PR DESCRIPTION
During development, the system parameter `account_banking_ach_direct_debit_portal.credit_card_surcharge` was missing. This caused issues when accessing or relying on the parameter value in logic or templates. This fix adds the missing parameter with a default value of `3.0` via a data file.

cc @chaule97