### PR TITLE
[16.0][ADD] account_banking_ach_direct_debit_portal: add fine-grained portal activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Available addons
 addon | version | maintainers | summary
 --- | --- | --- | ---
 [l10n_us_account_routing](l10n_us_account_routing/) | 16.0.1.0.0 |  | Add the routing numbers to the banks
-[l10n_us_form_1099](l10n_us_form_1099/) | 16.0.1.0.0 | [![max3903](https://github.com/max3903.png?size=30px)](https://github.com/max3903) | Manage 1099 Types and Suppliers
-[l10n_us_gaap](l10n_us_gaap/) | 16.0.1.0.1 | [![JordiBForgeFlow](https://github.com/JordiBForgeFlow.png?size=30px)](https://github.com/JordiBForgeFlow) | United States Sample GAAP Chart of Accounts
-[l10n_us_gaap_mis_report](l10n_us_gaap_mis_report/) | 16.0.1.0.1 | [![JordiBForgeFlow](https://github.com/JordiBForgeFlow.png?size=30px)](https://github.com/JordiBForgeFlow) | MIS Builder Templates for US Chart of Accounts
-[l10n_us_mis_financial_report](l10n_us_mis_financial_report/) | 16.0.1.1.0 | [![Christian-RB](https://github.com/Christian-RB.png?size=30px)](https://github.com/Christian-RB) | Profit & Loss (US) / Balance sheet (US) MIS templates
+[l10n_us_form_1099](l10n_us_form_1099/) | 16.0.1.0.0 | <a href='https://github.com/max3903'><img src='https://github.com/max3903.png' width='32' height='32' style='border-radius:50%;' alt='max3903'/></a> | Manage 1099 Types and Suppliers
+[l10n_us_gaap](l10n_us_gaap/) | 16.0.1.0.1 | <a href='https://github.com/JordiBForgeFlow'><img src='https://github.com/JordiBForgeFlow.png' width='32' height='32' style='border-radius:50%;' alt='JordiBForgeFlow'/></a> | United States Sample GAAP Chart of Accounts
+[l10n_us_gaap_mis_report](l10n_us_gaap_mis_report/) | 16.0.1.0.1 | <a href='https://github.com/JordiBForgeFlow'><img src='https://github.com/JordiBForgeFlow.png' width='32' height='32' style='border-radius:50%;' alt='JordiBForgeFlow'/></a> | MIS Builder Templates for US Chart of Accounts
+[l10n_us_mis_financial_report](l10n_us_mis_financial_report/) | 16.0.1.1.0 | <a href='https://github.com/Christian-RB'><img src='https://github.com/Christian-RB.png' width='32' height='32' style='border-radius:50%;' alt='Christian-RB'/></a> | Profit & Loss (US) / Balance sheet (US) MIS templates
 [l10n_us_partner_legal_number](l10n_us_partner_legal_number/) | 16.0.1.0.0 |  | Add Legal Number for North American Banking & Financials
 [partner_usps_address_validation](partner_usps_address_validation/) | 16.0.1.0.0 |  | Utilize the USPS open API for address validation
 

--- a/account_banking_ach_direct_debit_portal/__manifest__.py
+++ b/account_banking_ach_direct_debit_portal/__manifest__.py
@@ -21,7 +21,9 @@
         "views/invoice_templates.xml",
         "views/payment_templates.xml",
         "views/payment_checkout_templates.xml",
+        "views/alert_portal_templates.xml",
         "views/res_config_settings.xml",
+        "views/res_user_views.xml",
     ],
     "assets": {
         "web.assets_frontend": [

--- a/account_banking_ach_direct_debit_portal/controllers/__init__.py
+++ b/account_banking_ach_direct_debit_portal/controllers/__init__.py
@@ -4,3 +4,4 @@ from . import homepage
 from . import invoice
 from . import payment
 from . import plaid_server
+from . import user_portal

--- a/account_banking_ach_direct_debit_portal/controllers/autopay_rules.py
+++ b/account_banking_ach_direct_debit_portal/controllers/autopay_rules.py
@@ -6,6 +6,8 @@ from odoo.http import request
 
 from odoo.addons.portal.controllers.portal import CustomerPortal
 
+from ..controllers.user_portal import UserPortalController as user_portal
+
 
 class AutoPayRulesController(CustomerPortal):
     @http.route(
@@ -16,6 +18,9 @@ class AutoPayRulesController(CustomerPortal):
         methods=["GET", "POST"],
     )
     def portal_autopay_rules(self, **kw):
+        if not user_portal.is_ach_accessible():
+            return user_portal.deny_403()
+
         if request.httprequest.method == "POST":
             autopay_rule = kw.get("autopay_rule")
 

--- a/account_banking_ach_direct_debit_portal/controllers/homepage.py
+++ b/account_banking_ach_direct_debit_portal/controllers/homepage.py
@@ -3,6 +3,8 @@ from odoo.http import request
 
 from odoo.addons.portal.controllers.portal import CustomerPortal
 
+from ..controllers.user_portal import UserPortalController as user_portal
+
 
 class HomepageController(CustomerPortal):
     def _get_invoices_domain(self):
@@ -100,6 +102,7 @@ class HomepageController(CustomerPortal):
                 "display_currency": partner.currency_id,
                 "payments": payments,
                 "amount_due": amount_due,
+                "invisible_button": not user_portal.is_ach_accessible(),
             }
         )
 

--- a/account_banking_ach_direct_debit_portal/controllers/invoice.py
+++ b/account_banking_ach_direct_debit_portal/controllers/invoice.py
@@ -7,6 +7,8 @@ from odoo.osv import expression
 from odoo.addons.account.controllers.portal import PortalAccount
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 
+from ..controllers.user_portal import UserPortalController as user_portal
+
 
 class InvoiceController(PortalAccount):
     def _get_status_searchbar_filters(self):
@@ -171,6 +173,7 @@ class InvoiceController(PortalAccount):
                 "search": search,
                 "search_in": search_in,
                 "searchbar_inputs": searchbar_inputs,
+                "invisible_button": not user_portal.is_ach_accessible(),
             }
         )
 

--- a/account_banking_ach_direct_debit_portal/controllers/payment.py
+++ b/account_banking_ach_direct_debit_portal/controllers/payment.py
@@ -14,6 +14,8 @@ from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.controllers import portal as payment_portal
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 
+from ..controllers.user_portal import UserPortalController as user_portal
+
 PAYMENT_METHODS = [
     {
         "id": "1",
@@ -61,6 +63,9 @@ class PaymentController(CustomerPortal):
     def portal_my_payments(
         self, page=1, sortby=None, filterby=None, search="", search_in="all", **kw
     ):
+        if not user_portal.is_ach_accessible():
+            return user_portal.deny_403()
+
         ScheduledPayment = request.env["account.payment"]
 
         searchbar_inputs = {
@@ -178,6 +183,7 @@ class PaymentController(CustomerPortal):
             "total_amount": total_amount,
             "display_currency": display_currency,
             "select_payment_url": select_payment_url,
+            "invisible_button": not user_portal.is_ach_accessible(),
         }
 
         return request.render(
@@ -192,6 +198,9 @@ class PaymentController(CustomerPortal):
         methods=["GET", "POST"],
     )
     def manual_payment(self, **kw):
+        if not user_portal.is_ach_accessible():
+            return user_portal.deny_403()
+
         invoices = request.env["account.move"].search(
             self._get_invoices_domain(), limit=10
         )
@@ -211,6 +220,7 @@ class PaymentController(CustomerPortal):
             "invoices": invoices,
             "current_invoice": invoice,
             "selected_invoice_id": invoice_id,
+            "invisible_button": not user_portal.is_ach_accessible(),
         }
 
         return request.render(
@@ -328,6 +338,7 @@ class PaymentController(CustomerPortal):
             "surcharge_amount": surcharge_amount,
             "selected_payment_method": selected_payment_method,
             "payment_methods": payment_methods,
+            "invisible_button": not user_portal.is_ach_accessible(),
         }
 
         return request.render(
@@ -491,6 +502,9 @@ class PaymentController(CustomerPortal):
         methods=["GET"],
     )
     def payment_success(self, **kw):
+        if not user_portal.is_ach_accessible():
+            return user_portal.deny_403()
+
         return request.render(
             "account_banking_ach_direct_debit_portal.portal_payment_success"
         )

--- a/account_banking_ach_direct_debit_portal/controllers/user_portal.py
+++ b/account_banking_ach_direct_debit_portal/controllers/user_portal.py
@@ -1,0 +1,14 @@
+from odoo import http
+from odoo.http import request
+
+
+class UserPortalController(http.Controller):
+    @staticmethod
+    def is_ach_accessible():
+        return request.env.user.is_ach_portal_enabled_for_user()
+
+    @staticmethod
+    def deny_403():
+        return request.render(
+            "account_banking_ach_direct_debit_portal.alert_portal_403_template"
+        )

--- a/account_banking_ach_direct_debit_portal/data/res_config_settings_data.xml
+++ b/account_banking_ach_direct_debit_portal/data/res_config_settings_data.xml
@@ -10,4 +10,13 @@
         >account_banking_ach_direct_debit_portal.credit_card_surcharge</field>
         <field name="value">3.0</field>
     </record>
+
+    <record
+        id="default_param_enable_ach_payment_portal"
+        model="ir.config_parameter"
+        forcecreate="0"
+    >
+        <field name="key">account_banking_ach_direct_debit_portal.enable_portal</field>
+        <field name="value">selected_users_only</field>
+    </record>
 </odoo>

--- a/account_banking_ach_direct_debit_portal/models/__init__.py
+++ b/account_banking_ach_direct_debit_portal/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_bank
 from . import res_config_settings
 from . import res_partner_bank
 from . import res_partner
+from . import res_user

--- a/account_banking_ach_direct_debit_portal/models/res_config_settings.py
+++ b/account_banking_ach_direct_debit_portal/models/res_config_settings.py
@@ -35,3 +35,17 @@ class ResConfigSettings(models.TransientModel):
         help="Surcharge percentage to apply "
         "when customers pay with a credit card on the portal.",
     )
+
+    enable_portal = fields.Selection(
+        [
+            ("disabled", "Disabled"),
+            ("selected_users_only", "Selected Only User"),
+            ("for_all_portal_users", "For All Portal Users"),
+        ],
+        default="selected_users_only",
+        config_parameter="account_banking_ach_direct_debit_portal.enable_portal",
+        help="Controls who can access the ACH Payment Portal features:\n"
+        "- Disabled: Hide all ACH portal features\n"
+        "- Selected Users Only: Show to users with 'Enable ACH Payment Portal' enabled\n"
+        "- All Portal Users: Enable ACH features for all portal users",
+    )

--- a/account_banking_ach_direct_debit_portal/models/res_user.py
+++ b/account_banking_ach_direct_debit_portal/models/res_user.py
@@ -1,0 +1,39 @@
+from odoo import api, fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    enable_ach_payment_portal = fields.Boolean(
+        string="Enable ACH Payment Portal",
+        help="Allow this user to access ACH payment features on the portal.",
+    )
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ["enable_ach_payment_portal"]
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ["enable_ach_payment_portal"]
+
+    @api.model
+    def is_ach_portal_enabled_for_user(self):
+        self.ensure_one()
+        config_value = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(
+                "account_banking_ach_direct_debit_portal.enable_portal",
+                default="selected_users_only",
+            )
+        )
+        # Nobody is allowed to access
+        if config_value == "disabled":
+            return False
+        elif config_value == "selected_users_only":
+            return self.enable_ach_payment_portal
+        elif config_value == "for_all_portal_users":
+            return self.has_group("base.group_portal")
+        else:
+            return False

--- a/account_banking_ach_direct_debit_portal/views/alert_portal_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/alert_portal_templates.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="alert_portal_403_template" name="ACH Portal Access Denied">
+        <t t-call="portal.portal_layout">
+            <div class="container my-5">
+                <div
+                    class="alert alert-danger shadow-sm position-relative"
+                    role="alert"
+                >
+                    <button
+                        type="button"
+                        class="btn-close position-absolute end-0 top-0 mt-2 me-3"
+                        data-bs-dismiss="alert"
+                        aria-label="Close"
+                    />
+                    <h4 class="alert-heading">Access Denied</h4>
+                    <p>
+                        Sorry, you are not allowed to access this page.<br />
+                        The ACH Payment Portal has not been enabled for your account.
+                    </p>
+                    <hr />
+                    <p
+                        class="mb-0"
+                    >Please contact your administrator for more information.</p>
+                </div>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/account_banking_ach_direct_debit_portal/views/homepage_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/homepage_templates.xml
@@ -8,83 +8,91 @@
                 <div class="header mb-4">
                     <h2 class="header-title me-2">My Account</h2>
 
-                    <div class="wrapper-button">
-                        <a
-                            href="/autopay-rules"
-                            class="btn btn-blue me-2"
-                        >Auto Pay Settings</a>
-                        <a
-                            href="/manual-payment"
-                            class="btn btn-secondary"
-                        >Make a Payment</a>
-                    </div>
+                    <t t-if="not invisible_button">
+                        <div class="wrapper-button">
+                            <a
+                                href="/autopay-rules"
+                                class="btn btn-blue me-2"
+                            >Auto Pay Settings</a>
+                            <a
+                                href="/manual-payment"
+                                class="btn btn-secondary"
+                            >Make a Payment</a>
+                        </div>
+                    </t>
                 </div>
 
                 <div class="row g-4">
                     <div class="col-md-4 col-sm-12">
-                      <div class="card-credit">
-                        <div
+                        <div class="card-credit">
+                            <div
                                 class="d-flex justify-content-between align-items-center mb-2"
                             >
-                            <i class="icon fa fa-credit-card" />
+                                <i class="icon fa fa-credit-card" />
 
-                            <div class="info-icon">
-                                <i class="fa fa-info" />
-                                <div class="tooltip-box">
-                                    The total amount of credit available to you for purchases.
+                                <div class="info-icon">
+                                    <i class="fa fa-info" />
+                                    <div class="tooltip-box">
+                                        The total amount of credit available to you for purchases.
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <h6>Total credit limit</h6>
-                        <div class="amount"><span
+                            <h6>Total credit limit</h6>
+                            <div class="amount">
+                                <span
                                     t-esc="total_credit_limit"
                                     t-options='{"widget": "monetary", "display_currency": display_currency}'
-                                /></div>
-                      </div>
+                                />
+                            </div>
+                        </div>
                     </div>
 
                     <div class="col-md-4 col-sm-12">
-                      <div class="card-credit">
-                        <div
+                        <div class="card-credit">
+                            <div
                                 class="d-flex justify-content-between align-items-center mb-2"
                             >
-                            <i class="icon fa fa-credit-card" />
-                            <div class="info-icon">
-                                <i class="fa fa-info" />
-                                <div class="tooltip-box">
-                                    The remaining credit you can use, after subtracting any unpaid balances.
+                                <i class="icon fa fa-credit-card" />
+                                <div class="info-icon">
+                                    <i class="fa fa-info" />
+                                    <div class="tooltip-box">
+                                        The remaining credit you can use, after subtracting any
+                                        unpaid balances.
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <h6>Available credit</h6>
-                        <div class="amount"><span
+                            <h6>Available credit</h6>
+                            <div class="amount">
+                                <span
                                     t-esc="available_credit"
                                     t-options='{"widget": "monetary", "display_currency": display_currency}'
-                                /></div>
-                      </div>
+                                />
+                            </div>
+                        </div>
                     </div>
 
                     <div class="col-md-4 col-sm-12">
-                      <div class="card-credit">
-                        <div
+                        <div class="card-credit">
+                            <div
                                 class="d-flex justify-content-between align-items-center mb-2"
                             >
-                            <i class="icon fa fa-credit-card" />
-                            <div class="info-icon">
-                                <i class="fa fa-info" />
-                                <div class="tooltip-box">
-                                    The total unpaid balance from your invoices that is currently due.
+                                <i class="icon fa fa-credit-card" />
+                                <div class="info-icon">
+                                    <i class="fa fa-info" />
+                                    <div class="tooltip-box">
+                                        The total unpaid balance from your invoices that is
+                                        currently due.
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <h6>Amount due</h6>
-                        <div class="amount">
-                            <span
+                            <h6>Amount due</h6>
+                            <div class="amount">
+                                <span
                                     t-esc="amount_due"
                                     t-options='{"widget": "monetary", "display_currency": display_currency}'
                                 />
+                            </div>
                         </div>
-                      </div>
                     </div>
                 </div>
 
@@ -140,71 +148,89 @@
                                 <th>Status</th>
                                 <th>Action</th>
                             </tr>
-                          </thead>
-                          <tbody>
+                        </thead>
+                        <tbody>
                             <t t-foreach="invoices" t-as="invoice">
                                 <tr>
                                     <td>#<span t-field="invoice.name" /></td>
-                                    <td><span t-field="invoice.invoice_date" /></td>
-                                    <td><span t-field="invoice.invoice_date_due" /></td>
-                                    <td><span
+                                    <td>
+                                        <span t-field="invoice.invoice_date" />
+                                    </td>
+                                    <td>
+                                        <span t-field="invoice.invoice_date_due" />
+                                    </td>
+                                    <td>
+                                        <span
                                             t-esc="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual"
                                             t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'
-                                        /></td>
+                                        />
+                                    </td>
                                     <td class="tx_status">
                                         <t
                                             t-if="invoice.state == 'posted' and invoice.payment_state not in ('in_payment', 'paid', 'reversed')"
                                         >
                                             <span
                                                 class="badge rounded-pill text-bg-info"
-                                            ><i
+                                            >
+                                                <i
                                                     class="fa fa-fw fa-clock-o"
                                                     aria-label="Opened"
                                                     title="Opened"
                                                     role="img"
-                                                /><span
+                                                />
+                                                <span
                                                     class="d-none d-md-inline"
-                                                > Waiting for Payment</span></span>
+                                                > Waiting for Payment</span>
+                                            </span>
                                         </t>
                                         <t
                                             t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment')"
                                         >
                                             <span
                                                 class="badge rounded-pill text-bg-success"
-                                            ><i
+                                            >
+                                                <i
                                                     class="fa fa-fw fa-check"
                                                     aria-label="Paid"
                                                     title="Paid"
                                                     role="img"
-                                                /><span
+                                                />
+                                                <span
                                                     class="d-none d-md-inline"
-                                                > Paid</span></span>
+                                                > Paid</span>
+                                            </span>
                                         </t>
                                         <t
                                             t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'"
                                         >
                                             <span
                                                 class="badge rounded-pill text-bg-success"
-                                            ><i
+                                            >
+                                                <i
                                                     class="fa fa-fw fa-check"
                                                     aria-label="Reversed"
                                                     title="Reversed"
                                                     role="img"
-                                                /><span
+                                                />
+                                                <span
                                                     class="d-none d-md-inline"
-                                                > Reversed</span></span>
+                                                > Reversed</span>
+                                            </span>
                                         </t>
                                         <t t-if="invoice.state == 'cancel'">
                                             <span
                                                 class="badge rounded-pill text-bg-warning"
-                                            ><i
+                                            >
+                                                <i
                                                     class="fa fa-fw fa-remove"
                                                     aria-label="Cancelled"
                                                     title="Cancelled"
                                                     role="img"
-                                                /><span
+                                                />
+                                                <span
                                                     class="d-none d-md-inline"
-                                                > Cancelled</span></span>
+                                                > Cancelled</span>
+                                            </span>
                                         </t>
                                     </td>
                                     <td>
@@ -213,12 +239,12 @@
                                             t-att-title="invoice.name"
                                             class="btn btn-secondary rounded-pill px-3"
                                         >
-                                        View Invoice
-                                    </a>
+                                            View Invoice
+                                        </a>
                                     </td>
                                 </tr>
                             </t>
-                          </tbody>
+                        </tbody>
                     </table>
                 </div>
 
@@ -229,81 +255,96 @@
                             <t t-foreach="invoices" t-as="invoice">
                                 <tr class="invoice-row">
                                     <td>
-                                      <div class="label">Date</div>
-                                      <div class="value"><span
-                                                t-field="invoice.invoice_date"
-                                            /></div>
+                                        <div class="label">Date</div>
+                                        <div class="value">
+                                            <span t-field="invoice.invoice_date" />
+                                        </div>
                                     </td>
                                     <td>
-                                      <div class="label">Due Date</div>
-                                      <div class="value"><span
-                                                t-field="invoice.invoice_date_due"
-                                            /></div>
+                                        <div class="label">Due Date</div>
+                                        <div class="value">
+                                            <span t-field="invoice.invoice_date_due" />
+                                        </div>
                                     </td>
                                     <td>
-                                      <div class="label">Amount</div>
-                                      <div class="value"><span
+                                        <div class="label">Amount</div>
+                                        <div class="value">
+                                            <span
                                                 t-esc="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual"
                                                 t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'
-                                            /></div>
+                                            />
+                                        </div>
                                     </td>
                                     <td>
-                                      <div class="label">Status</div>
-                                      <div class="tx_status">
-                                        <t
+                                        <div class="label">Status</div>
+                                        <div class="tx_status">
+                                            <t
                                                 t-if="invoice.state == 'posted' and invoice.payment_state not in ('in_payment', 'paid', 'reversed')"
                                             >
-                                            <span
+                                                <span
                                                     class="badge rounded-pill text-bg-info"
-                                                ><i
+                                                >
+                                                    <i
                                                         class="fa fa-fw fa-clock-o"
                                                         aria-label="Opened"
                                                         title="Opened"
                                                         role="img"
-                                                    /><span
+                                                    />
+                                                    <span
                                                         class="d-none d-md-inline"
-                                                    > Waiting for Payment</span></span>
-                                        </t>
-                                        <t
+                                                    > Waiting for
+                                                        Payment</span>
+                                                </span>
+                                            </t>
+                                            <t
                                                 t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment')"
                                             >
-                                            <span
+                                                <span
                                                     class="badge rounded-pill text-bg-success"
-                                                ><i
+                                                >
+                                                    <i
                                                         class="fa fa-fw fa-check"
                                                         aria-label="Paid"
                                                         title="Paid"
                                                         role="img"
-                                                    /><span
+                                                    />
+                                                    <span
                                                         class="d-none d-md-inline"
-                                                    > Paid</span></span>
-                                        </t>
-                                        <t
+                                                    > Paid</span>
+                                                </span>
+                                            </t>
+                                            <t
                                                 t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'"
                                             >
-                                            <span
+                                                <span
                                                     class="badge rounded-pill text-bg-success"
-                                                ><i
+                                                >
+                                                    <i
                                                         class="fa fa-fw fa-check"
                                                         aria-label="Reversed"
                                                         title="Reversed"
                                                         role="img"
-                                                    /><span
+                                                    />
+                                                    <span
                                                         class="d-none d-md-inline"
-                                                    > Reversed</span></span>
-                                        </t>
-                                        <t t-if="invoice.state == 'cancel'">
-                                            <span
+                                                    > Reversed</span>
+                                                </span>
+                                            </t>
+                                            <t t-if="invoice.state == 'cancel'">
+                                                <span
                                                     class="badge rounded-pill text-bg-warning"
-                                                ><i
+                                                >
+                                                    <i
                                                         class="fa fa-fw fa-remove"
                                                         aria-label="Cancelled"
                                                         title="Cancelled"
                                                         role="img"
-                                                    /><span
+                                                    />
+                                                    <span
                                                         class="d-none d-md-inline"
-                                                    > Cancelled</span></span>
-                                        </t>
+                                                    > Cancelled</span>
+                                                </span>
+                                            </t>
                                         </div>
                                     </td>
                                     <td class="text-end">
@@ -312,7 +353,7 @@
                                             t-att-title="invoice.name"
                                             class="btn btn-secondary rounded-pill px-3 py-1"
                                         >
-                                        View Invoice
+                                            View Invoice
                                         </a>
                                     </td>
                                 </tr>
@@ -373,23 +414,31 @@
                                 <th>Status</th>
                                 <th>Action</th>
                             </tr>
-                          </thead>
-                          <tbody>
+                        </thead>
+                        <tbody>
                             <t t-foreach="payments" t-as="payment">
                                 <tr>
                                     <td>#<span t-field="payment.move_id.name" /></td>
-                                    <td><span t-field="payment.date" /></td>
-                                    <td><span t-field="payment.invoice_date_due" /></td>
-                                    <td><span t-field="payment.amount_total" /></td>
-                                    <td><span t-field="payment.payment_state" /></td>
+                                    <td>
+                                        <span t-field="payment.date" />
+                                    </td>
+                                    <td>
+                                        <span t-field="payment.invoice_date_due" />
+                                    </td>
+                                    <td>
+                                        <span t-field="payment.amount_total" />
+                                    </td>
+                                    <td>
+                                        <span t-field="payment.payment_state" />
+                                    </td>
                                     <td>
                                         <a class="btn btn-secondary rounded-pill px-3">
-                                        View Payment
-                                    </a>
+                                            View Payment
+                                        </a>
                                     </td>
                                 </tr>
                             </t>
-                          </tbody>
+                        </tbody>
                     </table>
                 </div>
 
@@ -400,34 +449,34 @@
                             <t t-foreach="payments" t-as="payment">
                                 <tr class="invoice-row">
                                     <td>
-                                    <div class="label">Invoice no</div>
-                                    <div class="value"><span
-                                                t-field="payment.move_id.name"
-                                            /></div>
+                                        <div class="label">Invoice no</div>
+                                        <div class="value">
+                                            <span t-field="payment.move_id.name" />
+                                        </div>
                                     </td>
                                     <td>
-                                    <div class="label">Date</div>
-                                    <div class="value"><span
-                                                t-field="payment.date"
-                                            /></div>
+                                        <div class="label">Date</div>
+                                        <div class="value">
+                                            <span t-field="payment.date" />
+                                        </div>
                                     </td>
                                     <td>
-                                    <div class="label">Due Date</div>
-                                    <div class="value"><span
-                                                t-field="payment.invoice_date_due"
-                                            /></div>
+                                        <div class="label">Due Date</div>
+                                        <div class="value">
+                                            <span t-field="payment.invoice_date_due" />
+                                        </div>
                                     </td>
                                     <td>
-                                    <div class="label">Amount</div>
-                                    <div class="value"><span
-                                                t-field="payment.amount_total"
-                                            /></div>
+                                        <div class="label">Amount</div>
+                                        <div class="value">
+                                            <span t-field="payment.amount_total" />
+                                        </div>
                                     </td>
                                     <td>
                                         <div class="label">Status</div>
-                                        <div class="value"><span
-                                                t-field="payment.payment_state"
-                                            /></div>
+                                        <div class="value">
+                                            <span t-field="payment.payment_state" />
+                                        </div>
                                     </td>
                                     <td class="text-end">
                                         <a class="btn btn-secondary rounded-pill px-3">

--- a/account_banking_ach_direct_debit_portal/views/invoice_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/invoice_templates.xml
@@ -49,26 +49,29 @@
                     t-call="account_banking_ach_direct_debit_portal.invoice_debit_portal_searchbar"
                 >
                     <t t-set="title">Invoices</t>
-
-                    <div
-                        class="action-wrapper d-flex align-items-center justify-content-end"
-                    >
-                        <a
-                            href="/manual-payment"
-                            class="btn btn-secondary manual-pay-btn me-2"
+                    <t t-if="not invisible_button">
+                        <div
+                            class="action-wrapper d-flex align-items-center justify-content-end"
                         >
-                            Pay Manually
-                        </a>
-                        <a href="/my/banks" class="btn btn-secondary manage-bank-btn">
-                            Manage bank accounts
-                        </a>
-                        <a
-                            class="dropdown-item btn btn-blue pay-btn d-none"
-                            href="javascript:void(0);"
-                        >
-                            <i class="fa fa-exchange me-2" /> Pay
-                        </a>
-                    </div>
+                            <a
+                                href="/manual-payment"
+                                class="btn btn-secondary manual-pay-btn me-2"
+                            >
+                                Pay Manually
+                            </a>
+                            <a
+                                href="/my/banks"
+                                class="btn btn-secondary manage-bank-btn"
+                            >
+                                Manage bank accounts
+                            </a>
+                            <a
+                                class="dropdown-item btn btn-blue pay-btn d-none"
+                                href="javascript:void(0);"
+                            >
+                                <i class="fa fa-exchange me-2" /> Pay </a>
+                        </div>
+                    </t>
                 </t>
 
                 <t t-if="not invoices">
@@ -81,7 +84,9 @@
                         <t t-call="portal.portal_table">
                             <thead>
                                 <tr class="active">
-                                    <th><input type="checkbox" /></th>
+                                    <th>
+                                        <input type="checkbox" />
+                                    </th>
                                     <th>Invoice no</th>
                                     <th>Date</th>
                                     <th class='d-none d-md-table-cell'>Due Date</th>
@@ -93,12 +98,14 @@
                             <tbody>
                                 <t t-foreach="invoices" t-as="invoice">
                                     <tr>
-                                        <td><input
+                                        <td>
+                                            <input
                                                 type="checkbox"
                                                 name="invoice_ids"
                                                 class="invoice-checkbox"
                                                 t-att-value="invoice.id"
-                                            /></td>
+                                            />
+                                        </td>
                                         <td>
                                             <t
                                                 t-esc="invoice.name"
@@ -106,7 +113,9 @@
                                             />
                                             <em t-else="">Draft Invoice</em>
                                         </td>
-                                        <td><span t-field="invoice.invoice_date" /></td>
+                                        <td>
+                                            <span t-field="invoice.invoice_date" />
+                                        </td>
                                         <td class='d-none d-md-table-cell'>
                                             <span t-field="invoice.invoice_date_due" />
                                         </td>
@@ -131,7 +140,8 @@
                                                     />
                                                     <span
                                                         class="d-none d-md-inline"
-                                                    > Waiting for Payment</span>
+                                                    > Waiting for
+                                                        Payment</span>
                                                 </span>
                                             </t>
                                             <t
@@ -192,7 +202,7 @@
                                                     data-bs-toggle="dropdown"
                                                     aria-expanded="false"
                                                 >
-                                                  ⋮
+                                                    ⋮
                                                 </button>
                                                 <ul
                                                     class="dropdown-menu dropdown-menu-end shadow-sm rounded-3"
@@ -204,8 +214,8 @@
                                                         >
                                                             <i
                                                                 class="fa fa-wpforms me-2"
-                                                            /> View invoice
-                                                        </a>
+                                                            /> View
+                                                            invoice </a>
                                                     </li>
                                                 </ul>
                                             </div>
@@ -259,65 +269,73 @@
 
 
                             <div class="mx-1">
-                              <strong>Status</strong>
-                              <div class="tx_status">
-                                <t
+                                <strong>Status</strong>
+                                <div class="tx_status">
+                                    <t
                                         t-if="invoice.state == 'posted' and invoice.payment_state not in ('in_payment', 'paid', 'reversed')"
                                     >
-                                    <span class="badge rounded-pill text-bg-info">
-                                        <i
+                                        <span class="badge rounded-pill text-bg-info">
+                                            <i
                                                 class="fa fa-fw fa-clock-o"
                                                 aria-label="Opened"
                                                 title="Opened"
                                                 role="img"
                                             />
-                                        <span
+                                            <span
                                                 class="d-none d-md-inline"
                                             >Waiting for Payment</span>
-                                    </span>
-                                </t>
-                                <t
+                                        </span>
+                                    </t>
+                                    <t
                                         t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment')"
                                     >
-                                    <span class="badge rounded-pill text-bg-success">
-                                        <i
+                                        <span
+                                            class="badge rounded-pill text-bg-success"
+                                        >
+                                            <i
                                                 class="fa fa-fw fa-check"
                                                 aria-label="Paid"
                                                 title="Paid"
                                                 role="img"
                                             />
-                                        <span class="d-none d-md-inline"> Paid</span>
-                                    </span>
-                                </t>
-                                <t
+                                            <span
+                                                class="d-none d-md-inline"
+                                            > Paid</span>
+                                        </span>
+                                    </t>
+                                    <t
                                         t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'"
                                     >
-                                    <span class="badge rounded-pill text-bg-success">
-                                        <i
+                                        <span
+                                            class="badge rounded-pill text-bg-success"
+                                        >
+                                            <i
                                                 class="fa fa-fw fa-check"
                                                 aria-label="Reversed"
                                                 title="Reversed"
                                                 role="img"
                                             />
-                                        <span
+                                            <span
                                                 class="d-none d-md-inline"
                                             > Reversed</span>
-                                    </span>
-                                </t>
-                                <t t-if="invoice.state == 'cancel'">
-                                    <span class="badge rounded-pill text-bg-warning">
-                                        <i
+                                        </span>
+                                    </t>
+                                    <t t-if="invoice.state == 'cancel'">
+                                        <span
+                                            class="badge rounded-pill text-bg-warning"
+                                        >
+                                            <i
                                                 class="fa fa-fw fa-remove"
                                                 aria-label="Cancelled"
                                                 title="Cancelled"
                                                 role="img"
                                             />
-                                        <span
+                                            <span
                                                 class="d-none d-md-inline"
                                             > Cancelled</span>
-                                    </span>
-                                </t>
-                            </div>
+                                        </span>
+                                    </t>
+                                </div>
                             </div>
 
                             <div class="dropdown-wrapper text-center">
@@ -327,7 +345,7 @@
                                     data-bs-toggle="dropdown"
                                     aria-expanded="false"
                                 >
-                                  ⋮
+                                    ⋮
                                 </button>
                                 <ul
                                     class="dropdown-menu dropdown-menu-end shadow-sm rounded-3"
@@ -339,8 +357,7 @@
                                         >
                                             <i
                                                 class="fa fa-wpforms me-2"
-                                            /> View invoice
-                                        </a>
+                                            /> View invoice </a>
                                     </li>
                                 </ul>
                             </div>

--- a/account_banking_ach_direct_debit_portal/views/payment_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/payment_templates.xml
@@ -27,16 +27,19 @@
                         <tbody>
                             <t t-foreach="payments" t-as="payment">
                                 <tr>
-                                    <td>
-                                        #<span t-field="payment.move_id.name" />
+                                    <td> #<span t-field="payment.move_id.name" />
                                     </td>
-                                    <td><span t-field="payment.date" /></td>
-                                    <td><span
+                                    <td>
+                                        <span t-field="payment.date" />
+                                    </td>
+                                    <td>
+                                        <span
                                             t-field="payment.bank_partner_id.display_name"
-                                        /></td>
-                                    <td class="text-center"><span
-                                            t-field="payment.amount_total"
-                                        /></td>
+                                        />
+                                    </td>
+                                    <td class="text-center">
+                                        <span t-field="payment.amount_total" />
+                                    </td>
                                     <td>
                                         <div class="dropdown-wrapper text-center">
                                             <button
@@ -45,18 +48,18 @@
                                                 data-bs-toggle="dropdown"
                                                 aria-expanded="false"
                                             >
-                                              ⋮
+                                                ⋮
                                             </button>
                                             <ul
                                                 class="dropdown-menu dropdown-menu-end shadow-sm rounded-3"
                                             >
                                                 <li>
-                                                <a class="dropdown-item" href="#"><i
+                                                    <a class="dropdown-item" href="#"><i
                                                             class="fa fa-edit me-2"
                                                         />Edit</a>
                                                 </li>
                                                 <li>
-                                                <a class="dropdown-item" href="#"><i
+                                                    <a class="dropdown-item" href="#"><i
                                                             class="fa fa-times me-2"
                                                         /> Cancel</a>
                                                 </li>
@@ -77,8 +80,9 @@
                         class="table-responsive d-flex align-items-center justify-content-between p-3 border rounded mb-2"
                     >
                         <div class="mx-1">
-                            <strong>Linked invoices</strong>
-                            #<span t-field="payment.move_id.name" />
+                            <strong>Linked invoices</strong> #<span
+                                t-field="payment.move_id.name"
+                            />
                         </div>
                         <div class="mx-1">
                             <strong>Schedule Date</strong>
@@ -107,13 +111,11 @@
                             >
                                 <li>
                                     <a class="dropdown-item" href="#">
-                                        <i class="fa fa-edit me-2" /> Edit
-                                    </a>
+                                        <i class="fa fa-edit me-2" /> Edit </a>
                                 </li>
                                 <li>
                                     <a class="dropdown-item" href="#">
-                                        <i class="fa fa-times me-2" /> Cancel
-                                    </a>
+                                        <i class="fa fa-times me-2" /> Cancel </a>
                                 </li>
                             </ul>
                         </div>
@@ -137,278 +139,295 @@
 
             <div id="payment" class="container my-4">
                 <div class="row">
-                  <div class="left col-md-8 mb-3">
-                    <div class="card detail h-100">
-                        <div class="card-header">
-                            <h5 class="card-title">Details</h5>
-                        </div>
+                    <div class="left col-md-8 mb-3">
+                        <div class="card detail h-100">
+                            <div class="card-header">
+                                <h5 class="card-title">Details</h5>
+                            </div>
 
-                        <div class="table-responsive d-none d-md-block border-0">
-                            <table class="table mb-0 bg-white o_portal_my_doc_table">
-                                <thead class="thead-light">
-                                    <tr>
-                                      <th>Invoice no</th>
-                                      <th>Date</th>
-                                      <th>Due Date</th>
-                                      <th>Amount</th>
-                                      <th>Status</th>
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    <t t-foreach="invoices" t-as="invoice">
+                            <div class="table-responsive d-none d-md-block border-0">
+                                <table
+                                    class="table mb-0 bg-white o_portal_my_doc_table"
+                                >
+                                    <thead class="thead-light">
                                         <tr>
-                                            <td><span t-field="invoice.name" /></td>
-                                            <td><span
+                                            <th>Invoice no</th>
+                                            <th>Date</th>
+                                            <th>Due Date</th>
+                                            <th>Amount</th>
+                                            <th>Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-foreach="invoices" t-as="invoice">
+                                            <tr>
+                                                <td>
+                                                    <span t-field="invoice.name" />
+                                                </td>
+                                                <td>
+                                                    <span
                                                         t-field="invoice.invoice_date"
-                                                    /></td>
-                                            <td><span
+                                                    />
+                                                </td>
+                                                <td>
+                                                    <span
                                                         t-field="invoice.invoice_date_due"
-                                                    /></td>
-                                            <td>
-                                                <span
+                                                    />
+                                                </td>
+                                                <td>
+                                                    <span
                                                         t-esc="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual"
                                                         t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'
                                                     />
-                                            </td>
-                                            <td class="tx_status text-center">
-                                                <t
+                                                </td>
+                                                <td class="tx_status text-center">
+                                                    <t
                                                         t-if="invoice.state == 'posted' and invoice.payment_state not in ('in_payment', 'paid', 'reversed')"
                                                     >
-                                                    <span
+                                                        <span
                                                             class="badge rounded-pill text-bg-info"
                                                         >
-                                                        <i
+                                                            <i
                                                                 class="fa fa-fw fa-clock-o"
                                                                 aria-label="Opened"
                                                                 title="Opened"
                                                                 role="img"
                                                             />
-                                                        <span
+                                                            <span
                                                                 class="d-none d-md-inline"
-                                                            > Waiting for Payment</span>
-                                                    </span>
-                                                </t>
-                                                <t
+                                                            > Waiting
+                                                                for Payment</span>
+                                                        </span>
+                                                    </t>
+                                                    <t
                                                         t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment')"
                                                     >
-                                                    <span
+                                                        <span
                                                             class="badge rounded-pill text-bg-success"
                                                         >
-                                                        <i
+                                                            <i
                                                                 class="fa fa-fw fa-check"
                                                                 aria-label="Paid"
                                                                 title="Paid"
                                                                 role="img"
                                                             />
-                                                        <span
+                                                            <span
                                                                 class="d-none d-md-inline"
                                                             > Paid</span>
-                                                    </span>
-                                                </t>
-                                                <t
+                                                        </span>
+                                                    </t>
+                                                    <t
                                                         t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'"
                                                     >
-                                                    <span
+                                                        <span
                                                             class="badge rounded-pill text-bg-success"
                                                         >
-                                                        <i
+                                                            <i
                                                                 class="fa fa-fw fa-check"
                                                                 aria-label="Reversed"
                                                                 title="Reversed"
                                                                 role="img"
                                                             />
-                                                        <span
+                                                            <span
                                                                 class="d-none d-md-inline"
                                                             > Reversed</span>
-                                                    </span>
-                                                </t>
-                                                <t t-if="invoice.state == 'cancel'">
-                                                    <span
+                                                        </span>
+                                                    </t>
+                                                    <t t-if="invoice.state == 'cancel'">
+                                                        <span
                                                             class="badge rounded-pill text-bg-warning"
                                                         >
-                                                        <i
+                                                            <i
                                                                 class="fa fa-fw fa-remove"
                                                                 aria-label="Cancelled"
                                                                 title="Cancelled"
                                                                 role="img"
                                                             />
-                                                        <span
+                                                            <span
                                                                 class="d-none d-md-inline"
                                                             > Cancelled</span>
-                                                    </span>
-                                                </t>
-                                            </td>
-                                        </tr>
-                                    </t>
-                                  </tbody>
-                            </table>
-                        </div>
+                                                        </span>
+                                                    </t>
+                                                </td>
+                                            </tr>
+                                        </t>
+                                    </tbody>
+                                </table>
+                            </div>
 
-                        <div
+                            <div
                                 class="table-responsive d-md-none border rounded px-3 py-2"
                             >
-                            <table
+                                <table
                                     class="table o_portal_my_doc_table align-middle mb-0"
                                 >
-                                <tbody>
-                                    <t t-foreach="invoices" t-as="invoice">
-                                        <tr>
-                                            <td>
-                                              <div class="label">Invoice No</div>
-                                              <div class="value"><span
-                                                            t-field="invoice.name"
-                                                        /></div>
-                                            </td>
-                                            <td>
-                                              <div class="label">Amount</div>
-                                              <div class="value">
-                                                <span
+                                    <tbody>
+                                        <t t-foreach="invoices" t-as="invoice">
+                                            <tr>
+                                                <td>
+                                                    <div class="label">Invoice No</div>
+                                                    <div class="value">
+                                                        <span t-field="invoice.name" />
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <div class="label">Amount</div>
+                                                    <div class="value">
+                                                        <span
                                                             t-esc="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual"
                                                             t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'
                                                         />
-                                              </div>
-                                            </td>
-                                            <td>
-                                              <div class="label">Date</div>
-                                              <div class="value">
-                                                <span t-field="invoice.invoice_date" />
-                                              </div>
-                                            </td>
-                                            <td>
-                                                <div class="label">Due Date</div>
-                                                <div class="value">
-                                                    <span
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <div class="label">Date</div>
+                                                    <div class="value">
+                                                        <span
+                                                            t-field="invoice.invoice_date"
+                                                        />
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <div class="label">Due Date</div>
+                                                    <div class="value">
+                                                        <span
                                                             t-field="invoice.invoice_date_due"
                                                         />
-                                                </div>
-                                              </td>
-                                            <td>
-                                                <div class="label">Status</div>
-                                                <div class="tx_status text-center">
-                                                    <t
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                    <div class="label">Status</div>
+                                                    <div class="tx_status text-center">
+                                                        <t
                                                             t-if="invoice.state == 'posted' and invoice.payment_state not in ('in_payment', 'paid', 'reversed')"
                                                         >
-                                                        <span
+                                                            <span
                                                                 class="badge rounded-pill text-bg-info"
                                                             >
-                                                            <i
+                                                                <i
                                                                     class="fa fa-fw fa-clock-o"
                                                                     aria-label="Opened"
                                                                     title="Opened"
                                                                     role="img"
                                                                 />
-                                                            <span
+                                                                <span
                                                                     class="d-none d-md-inline"
-                                                                > Waiting for Payment</span>
-                                                        </span>
-                                                    </t>
-                                                    <t
+                                                                >
+                                                                    Waiting for Payment</span>
+                                                            </span>
+                                                        </t>
+                                                        <t
                                                             t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment')"
                                                         >
-                                                        <span
+                                                            <span
                                                                 class="badge rounded-pill text-bg-success"
                                                             >
-                                                            <i
+                                                                <i
                                                                     class="fa fa-fw fa-check"
                                                                     aria-label="Paid"
                                                                     title="Paid"
                                                                     role="img"
                                                                 />
-                                                            <span
+                                                                <span
                                                                     class="d-none d-md-inline"
                                                                 > Paid</span>
-                                                        </span>
-                                                    </t>
-                                                    <t
+                                                            </span>
+                                                        </t>
+                                                        <t
                                                             t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'"
                                                         >
-                                                        <span
+                                                            <span
                                                                 class="badge rounded-pill text-bg-success"
                                                             >
-                                                            <i
+                                                                <i
                                                                     class="fa fa-fw fa-check"
                                                                     aria-label="Reversed"
                                                                     title="Reversed"
                                                                     role="img"
                                                                 />
-                                                            <span
+                                                                <span
                                                                     class="d-none d-md-inline"
-                                                                > Reversed</span>
-                                                        </span>
-                                                    </t>
-                                                    <t t-if="invoice.state == 'cancel'">
-                                                        <span
+                                                                >
+                                                                    Reversed</span>
+                                                            </span>
+                                                        </t>
+                                                        <t
+                                                            t-if="invoice.state == 'cancel'"
+                                                        >
+                                                            <span
                                                                 class="badge rounded-pill text-bg-warning"
                                                             >
-                                                            <i
+                                                                <i
                                                                     class="fa fa-fw fa-remove"
                                                                     aria-label="Cancelled"
                                                                     title="Cancelled"
                                                                     role="img"
                                                                 />
-                                                            <span
+                                                                <span
                                                                     class="d-none d-md-inline"
-                                                                > Cancelled</span>
-                                                        </span>
-                                                    </t>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    </t>
-                                </tbody>
-                            </table>
+                                                                >
+                                                                    Cancelled</span>
+                                                            </span>
+                                                        </t>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </t>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
-                  </div>
 
-                  <div class="right col-md-4 mb-3">
-                    <div class="card summary h-100">
-                        <div class="card-body">
-                            <h5 class="card-title">Summary</h5>
+                    <div class="right col-md-4 mb-3">
+                        <div class="card summary h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Summary</h5>
 
-                            <div class="wrapper">
-                                <div class="d-flex justify-content-between mb-2">
-                                    <span class="label">Quantity</span>
-                                    <span t-esc="quantity" />
-                                </div>
+                                <div class="wrapper">
+                                    <div class="d-flex justify-content-between mb-2">
+                                        <span class="label">Quantity</span>
+                                        <span t-esc="quantity" />
+                                    </div>
 
-                                <div
+                                    <div
                                         class="d-flex justify-content-between border-top-lg pt-2 mb-2"
                                     >
-                                    <span class="label">Total amount</span>
-                                    <span
+                                        <span class="label">Total amount</span>
+                                        <span
                                             t-esc="total_amount"
                                             t-options='{"widget": "monetary", "display_currency": display_currency}'
                                         />
-                                </div>
+                                    </div>
 
-                                <div
+                                    <div
                                         class="d-flex justify-content-between border-top-lg pt-2 mb-2"
                                     >
-                                    <span class="label">Due date</span>
-                                    <span t-esc="earliest_due_date" />
-                                </div>
+                                        <span class="label">Due date</span>
+                                        <span t-esc="earliest_due_date" />
+                                    </div>
 
-                                <div
+                                    <div
                                         class="d-flex justify-content-between fw-bold border-top pt-2 mt-2"
                                     >
-                                    <span class="label">Total amount</span>
-                                    <span
+                                        <span class="label">Total amount</span>
+                                        <span
                                             t-esc="total_amount"
                                             t-options='{"widget": "monetary", "display_currency": display_currency}'
                                         />
+                                    </div>
+                                    <t t-if="not invisible_button">
+                                        <a
+                                            t-att-href="select_payment_url"
+                                            class="btn btn-submit w-100"
+                                        >
+                                            Make a Payment
+                                        </a>
+                                    </t>
                                 </div>
-                                <a
-                                        t-att-href="select_payment_url"
-                                        class="btn btn-submit w-100"
-                                    >
-                                    Make a Payment
-                                </a>
                             </div>
-
                         </div>
                     </div>
-                  </div>
                 </div>
             </div>
         </t>
@@ -424,172 +443,182 @@
 
             <div id="payment" class="container my-4">
                 <div class="row">
-                  <div class="col-md-8 mb-3">
-                    <div class="card h-100">
-                        <div class="card-header">
-                            <div
+                    <div class="col-md-8 mb-3">
+                        <div class="card h-100">
+                            <div class="card-header">
+                                <div
                                     class="d-flex justify-content-between align-items-center underline"
                                 >
-                                <h5 class="card-title">Invoice</h5>
+                                    <h5 class="card-title">Invoice</h5>
 
-                                <select
+                                    <select
                                         id="manual-invoice-select"
                                         class="invoice-select"
                                     >
-                                    <option
-                                            t-att-selected="not selected_invoice_id"
-                                        >Select an invoice</option>
-                                    <t t-foreach="invoices" t-as="invoice">
                                         <option
+                                            t-att-selected="not selected_invoice_id"
+                                        >Select an
+                                            invoice</option>
+                                        <t t-foreach="invoices" t-as="invoice">
+                                            <option
                                                 t-att-value="invoice.id"
                                                 t-att-selected="invoice.id == selected_invoice_id and 'true' or None"
                                             >
-                                            <t t-esc="invoice.name" />
-                                        </option>
-                                    </t>
-                                </select>
+                                                <t t-esc="invoice.name" />
+                                            </option>
+                                        </t>
+                                    </select>
 
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="table-responsive border-0">
-                            <table class="table mb-0 bg-white o_portal_my_doc_table">
-                                <thead class="thead-light">
-                                    <tr>
-                                      <th>Invoice no</th>
-                                      <th>Date</th>
-                                      <th>Due Date</th>
-                                      <th>Amount</th>
-                                      <th>Status</th>
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    <tr t-if="current_invoice">
-                                        <td><span t-esc="current_invoice.name" /></td>
-                                        <td>
-                                            <span
+                            <div class="table-responsive border-0">
+                                <table
+                                    class="table mb-0 bg-white o_portal_my_doc_table"
+                                >
+                                    <thead class="thead-light">
+                                        <tr>
+                                            <th>Invoice no</th>
+                                            <th>Date</th>
+                                            <th>Due Date</th>
+                                            <th>Amount</th>
+                                            <th>Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr t-if="current_invoice">
+                                            <td>
+                                                <span t-esc="current_invoice.name" />
+                                            </td>
+                                            <td>
+                                                <span
                                                     t-esc="current_invoice.invoice_date"
                                                 />
-                                        </td>
-                                        <td>
-                                            <span
+                                            </td>
+                                            <td>
+                                                <span
                                                     t-esc="current_invoice.invoice_date_due"
                                                 />
-                                        </td>
-                                        <td>
-                                            <span
+                                            </td>
+                                            <td>
+                                                <span
                                                     t-esc="-current_invoice.amount_residual if current_invoice.move_type == 'out_refund' else current_invoice.amount_residual"
                                                     t-options='{"widget": "monetary", "display_currency": current_invoice.currency_id}'
                                                 />
-                                        </td>
-                                        <td class="tx_status text-center">
-                                            <t
+                                            </td>
+                                            <td class="tx_status text-center">
+                                                <t
                                                     t-if="current_invoice.state == 'posted' and current_invoice.payment_state not in ('in_payment', 'paid', 'reversed')"
                                                 >
-                                                <span
+                                                    <span
                                                         class="badge rounded-pill text-bg-info"
                                                     >
-                                                    <i
+                                                        <i
                                                             class="fa fa-fw fa-clock-o"
                                                             aria-label="Opened"
                                                             title="Opened"
                                                             role="img"
                                                         />
-                                                    <span
+                                                        <span
                                                             class="d-none d-md-inline"
-                                                        > Waiting for Payment</span>
-                                                </span>
-                                            </t>
-                                            <t
+                                                        > Waiting for
+                                                            Payment</span>
+                                                    </span>
+                                                </t>
+                                                <t
                                                     t-if="current_invoice.state == 'posted' and current_invoice.payment_state in ('paid', 'in_payment')"
                                                 >
-                                                <span
+                                                    <span
                                                         class="badge rounded-pill text-bg-success"
                                                     >
-                                                    <i
+                                                        <i
                                                             class="fa fa-fw fa-check"
                                                             aria-label="Paid"
                                                             title="Paid"
                                                             role="img"
                                                         />
-                                                    <span
+                                                        <span
                                                             class="d-none d-md-inline"
                                                         > Paid</span>
-                                                </span>
-                                            </t>
-                                            <t
+                                                    </span>
+                                                </t>
+                                                <t
                                                     t-if="current_invoice.state == 'posted' and current_invoice.payment_state == 'reversed'"
                                                 >
-                                                <span
+                                                    <span
                                                         class="badge rounded-pill text-bg-success"
                                                     >
-                                                    <i
+                                                        <i
                                                             class="fa fa-fw fa-check"
                                                             aria-label="Reversed"
                                                             title="Reversed"
                                                             role="img"
                                                         />
-                                                    <span
+                                                        <span
                                                             class="d-none d-md-inline"
                                                         > Reversed</span>
-                                                </span>
-                                            </t>
-                                            <t t-if="current_invoice.state == 'cancel'">
-                                                <span
+                                                    </span>
+                                                </t>
+                                                <t
+                                                    t-if="current_invoice.state == 'cancel'"
+                                                >
+                                                    <span
                                                         class="badge rounded-pill text-bg-warning"
                                                     >
-                                                    <i
+                                                        <i
                                                             class="fa fa-fw fa-remove"
                                                             aria-label="Cancelled"
                                                             title="Cancelled"
                                                             role="img"
                                                         />
-                                                    <span
+                                                        <span
                                                             class="d-none d-md-inline"
                                                         > Cancelled</span>
-                                                </span>
-                                            </t>
-                                        </td>
-                                    </tr>
-                                  </tbody>
-                            </table>
+                                                    </span>
+                                                </t>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
-                  </div>
 
-                  <div class="col-md-4 mb-3">
-                    <div class="card summary h-100">
-                      <div class="card-body">
-                        <h5 class="card-title">Details</h5>
+                    <div class="col-md-4 mb-3">
+                        <div class="card summary h-100">
+                            <div class="card-body">
+                                <h5 class="card-title">Details</h5>
 
-                        <t t-if="invoice">
-                            <div class="d-flex justify-content-between mb-2">
-                                <span class="label">Invoice no</span>
-                                <span t-esc="invoice.name" />
-                            </div>
-                            <div
+                                <t t-if="invoice">
+                                    <div class="d-flex justify-content-between mb-2">
+                                        <span class="label">Invoice no</span>
+                                        <span t-esc="invoice.name" />
+                                    </div>
+                                    <div
                                         class="d-flex justify-content-between border-top pt-2 mb-2"
                                     >
-                                <span class="label">Amount due</span>
-                                <span
+                                        <span class="label">Amount due</span>
+                                        <span
                                             t-esc="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual"
                                             t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'
                                         />
-                            </div>
-                            <div
+                                    </div>
+                                    <div
                                         class="d-flex justify-content-between border-top pt-2 mb-2"
                                     >
-                                <span class="label">Due date</span>
-                                <span t-esc="invoice.invoice_date_due" />
+                                        <span class="label">Due date</span>
+                                        <span t-esc="invoice.invoice_date_due" />
+                                    </div>
+                                </t>
+                                <t t-if="not invisible_button">
+                                    <a
+                                        href="/select-payment-method"
+                                        class="btn btn-submit w-100 mt-5"
+                                    >Make a Payment</a>
+                                </t>
                             </div>
-                        </t>
-                        <a
-                                    href="/select-payment-method"
-                                    class="btn btn-submit w-100 mt-5"
-                                >Make a Payment</a>
-                      </div>
+                        </div>
                     </div>
-                  </div>
                 </div>
             </div>
 
@@ -667,7 +696,8 @@
                                                 t-foreach="invoices"
                                                 t-as="invoice"
                                                 t-field="invoice.name"
-                                            /></div>
+                                            />
+                                        </div>
                                     </div>
                                     <div
                                         class="d-flex justify-content-between border-top pt-2 mb-2"
@@ -716,14 +746,16 @@
                                             t-options='{"widget": "monetary", "display_currency": display_currency}'
                                         />
                                     </div>
-                                    <button
-                                        type="submit"
-                                        name="action"
-                                        value="make_payment"
-                                        class="btn btn-submit w-100 mt-2"
-                                    >
-                                        Make a Payment
-                                    </button>
+                                    <t t-if="not invisible_button">
+                                        <button
+                                            type="submit"
+                                            name="action"
+                                            value="make_payment"
+                                            class="btn btn-submit w-100 mt-2"
+                                        >
+                                            Make a Payment
+                                        </button>
+                                    </t>
                                 </div>
                             </div>
                         </div>
@@ -759,17 +791,16 @@
                             <div class="card-body mx-5 my-4">
                                 <h3
                                     class="card-title text-primary blue-title fw-bold pb-4 mb-4"
-                                >Please Confirm Your Payment Details</h3>
+                                >Please
+                                    Confirm Your Payment Details</h3>
 
                                 <div class="mb-2 row">
                                     <label class="col-sm-4 fw-bold">Invoice no#</label>
-                                    <div class="col-sm-8 fw-bold value"><t
-                                            t-foreach="invoices"
-                                            t-as="invoice"
-                                        ><span
-                                                class="me-1"
-                                                t-field="invoice.name"
-                                            /></t></div>
+                                    <div class="col-sm-8 fw-bold value">
+                                        <t t-foreach="invoices" t-as="invoice">
+                                            <span class="me-1" t-field="invoice.name" />
+                                        </t>
+                                    </div>
                                 </div>
                                 <div class="mb-2 row">
                                     <label class="col-sm-4 fw-bold">Amount due</label>
@@ -823,18 +854,15 @@
                                 <div class="alert">
                                     <i
                                         class="fa fa-exclamation-triangle text-warning me-2"
-                                    />
-                                    Please double-check all the information above before proceeding.
-                                </div>
+                                    /> Please
+                                    double-check all the information above before proceeding. </div>
 
                                 <div class="d-flex justify-content-center">
                                     <a
                                         href="javascript:history.back()"
                                         class="btn btn-light me-2 border"
                                     >
-                                        <i class="fa fa-angle-left me-1" />
-                                        Back
-                                    </a>
+                                        <i class="fa fa-angle-left me-1" /> Back </a>
                                     <button
                                         type="submit"
                                         class="btn btn-primary btn-blue"

--- a/account_banking_ach_direct_debit_portal/views/res_config_settings.xml
+++ b/account_banking_ach_direct_debit_portal/views/res_config_settings.xml
@@ -71,6 +71,32 @@
                         </div>
                     </div>
                 </div>
+                <h2>ACH Payment Portal Activation</h2>
+                <div
+                    class="row mt16 o_settings_container"
+                    id="payment_portal_activation_settings"
+                >
+                    <div class="col-12 col-lg-12 o_setting_box">
+                        <div class="text-muted">
+                            <p
+                                class="mb-0"
+                            >Controls who can access the ACH Payment Portal features:</p>
+                            <ul class="">
+                                <li>Disabled: Hide all ACH portal features</li>
+                                <li
+                                >Selected Users Only: Show to users with 'Enable ACH Payment Portal' enabled</li>
+                                <li
+                                >All Portal Users: Enable ACH features for all portal users</li>
+                            </ul>
+                        </div>
+                        <div class="o_setting_right_pane mt16">
+                            <label for="enable_portal" />
+                            <div>
+                                <field name="enable_portal" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/account_banking_ach_direct_debit_portal/views/res_user_views.xml
+++ b/account_banking_ach_direct_debit_portal/views/res_user_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="name">res.users.form.inherit</field>
+        <field name="model">res.users</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='preferences']" position="after">
+                <page string="ACH Payment Portal" name="ach_payment_portal">
+                    <group>
+                        <field
+                            name="enable_ach_payment_portal"
+                            string="ACH Payment Portal"
+                            widget="boolean_toggle"
+                        />
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
#### Features Added:

1. **New System Parameter**: `account_banking_ach_direct_debit_portal.enable_portal`
Determines who can access ACH-related features on the portal. Possible values:

   * `'disabled'`: Hide all ACH portal features.
   * `'selected_users_only'` (default): Only users with the **Enable ACH Payment Portal** flag can access.
   * `'for_all_portal_users'`: All portal users can access ACH features.

3. **New Configuration Field in Settings to store in system parameter (as above)**: `enable_portal`

Visible in: *General Settings (Invoicing) > ACH Payment Portal Activation
   
![image](https://github.com/user-attachments/assets/4a0c8c5e-1ad3-4f66-b524-6b382b00b531)


4. **New boolean field on `res.users`**: `enable_ach_payment_portal`

   * Visible in: Settings > Users & Comanies > Users
   * Used when `enable_portal` is set to `'selected_users_only'` to controls ACH access on a per-user.
   
![image](https://github.com/user-attachments/assets/66784467-e2f8-4975-9a85-dd723fd42d61)


5. **Portal Behavior Adjustments**:

   * ACH-related routes (e.g. `/my/payments`, `/manual-payment`, etc.) will redirect to an error page (`403`) if access conditions are not met.
   * Portal buttons related to ACH (e.g. **Auto Pay Settings**, **Make a Payment**, **Manage Bank Accounts**) will be conditionally hidden based on the configuration and user permissions.

![image](https://github.com/user-attachments/assets/4b15b46a-4260-444a-9ce0-9bc44deff080)
