### PR TITLE
[16.0][UPD] account_banking_ach_direct_debit_portal: add surchagre/discount line for customer invoice

### DIFF
--- a/account_banking_ach_direct_debit_portal/__init__.py
+++ b/account_banking_ach_direct_debit_portal/__init__.py
@@ -1,2 +1,3 @@
 from . import controllers
 from . import models
+from . import wizard

--- a/account_banking_ach_direct_debit_portal/controllers/payment.py
+++ b/account_banking_ach_direct_debit_portal/controllers/payment.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 import werkzeug.urls
 
@@ -13,6 +14,9 @@ from odoo.addons.payment.controllers import portal as payment_portal
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 
 from ..controllers.user_portal import UserPortalController as user_portal
+
+_logger = logging.getLogger(__name__)
+
 
 PAYMENT_METHODS = [
     {
@@ -215,12 +219,20 @@ class PaymentController(CustomerPortal):
             min(invoices.mapped("invoice_date_due")) if invoices else None
         )
 
-        base_total_amount = sum(
-            -inv.amount_residual
-            if inv.move_type == "out_refund"
-            else inv.amount_residual
-            for inv in invoices
-        )
+        surcharge_percent = self._get_surcharge_percent()
+        discount_percent = self._get_plaid_discount_percent()
+        base_total_amount = 0.0
+        surcharge_amount = 0.0
+        discount_amount = 0.0
+        for inv in invoices:
+            amount_residual = (
+                -inv.amount_residual
+                if inv.move_type == "out_refund"
+                else inv.amount_residual
+            )
+            base_total_amount += amount_residual
+            surcharge_amount += amount_residual * surcharge_percent / 100
+            discount_amount += amount_residual * discount_percent / 100
 
         display_currency = invoices[0].currency_id if invoices else None
 
@@ -233,25 +245,13 @@ class PaymentController(CustomerPortal):
             query_params
         )
 
-        surcharge_percent = self._get_surcharge_percent()
-        surcharge_amount = 0.0
-
-        plaid_discount_percent = self._get_plaid_discount_percent()
-        discount_amount = 0.0
-
         company = request.env.user.partner_id.company_id
         currency = display_currency or company.currency_id
         total_amount = base_total_amount
 
         if selected_payment_method == "credit_card":
-            surcharge_amount = currency.round(
-                base_total_amount * surcharge_percent / 100
-            )
             total_amount += surcharge_amount
         elif selected_payment_method == "bank_account":
-            discount_amount = currency.round(
-                base_total_amount * plaid_discount_percent / 100
-            )
             total_amount -= discount_amount
 
         total_amount_format = float_repr(
@@ -270,7 +270,7 @@ class PaymentController(CustomerPortal):
         payment_methods[0].update(
             {
                 "checked": selected_payment_method == "bank_account",
-                "note": f"{plaid_discount_percent:.4g}% Discount "  # noqa: E231
+                "note": f"{discount_percent:.4g}% Discount "  # noqa: E231
                 "(with plaid verification)"
                 if surcharge_percent
                 else "",
@@ -289,20 +289,18 @@ class PaymentController(CustomerPortal):
             "page_name": "select_payment_method",
             "invoices": invoices,
             "earliest_due_date": earliest_due_date,
-            "base_total_amount": base_total_amount,
-            "total_amount": total_amount,
+            "base_total_amount": currency.round(base_total_amount),
+            "total_amount": currency.round(total_amount),
             "display_currency": display_currency,
             "make_payment_url": make_payment_url,
             "surcharge_percent": (
                 surcharge_percent if selected_payment_method == "credit_card" else 0.0
             ),
-            "surcharge_amount": surcharge_amount,
+            "surcharge_amount": currency.round(surcharge_amount),
             "plaid_discount_percent": (
-                plaid_discount_percent
-                if selected_payment_method == "bank_account"
-                else 0.0
+                discount_percent if selected_payment_method == "bank_account" else 0.0
             ),
-            "discount_amount": discount_amount,
+            "discount_amount": currency.round(discount_amount),
             "selected_payment_method": selected_payment_method,
             "payment_methods": payment_methods,
             "invisible_button": not user_portal.is_ach_accessible(),
@@ -349,30 +347,27 @@ class PaymentController(CustomerPortal):
         )
 
         total_due = sum(invoices.mapped("amount_residual"))
-
-        total_amount = sum(
-            -inv.amount_residual
-            if inv.move_type == "out_refund"
-            else inv.amount_residual
-            for inv in invoices
-        )
-
-        company = request.env.user.partner_id.company_id
-        display_currency = invoices[0].currency_id if invoices else None
-        currency = display_currency or company.currency_id
-
+        surcharge_percent = self._get_surcharge_percent()
+        discount_percent = self._get_plaid_discount_percent()
+        total_amount = 0.0
         surcharge_amount = 0.0
+        discount_amount = 0
+        for inv in invoices:
+            amount_residual = (
+                -inv.amount_residual
+                if inv.move_type == "out_refund"
+                else inv.amount_residual
+            )
+            total_amount += amount_residual
+            surcharge_amount += amount_residual * surcharge_percent / 100
+            discount_amount += amount_residual * discount_percent / 100
+
+        display_currency = invoices[0].currency_id if invoices else None
+
         if payment_method == "credit_card":
-            surcharge_percent = self._get_surcharge_percent()
-            surcharge_amount = currency.round(total_amount * surcharge_percent / 100)
             total_amount += surcharge_amount
 
-        discount_amount = 0
         if payment_method == "bank_account":
-            plaid_discount_percent = self._get_plaid_discount_percent()
-            discount_amount = display_currency.round(
-                total_amount * plaid_discount_percent / 100
-            )
             total_amount -= discount_amount
 
         partner_banks = request.env["res.partner.bank"].search(
@@ -389,10 +384,10 @@ class PaymentController(CustomerPortal):
             "invoices": invoices,
             "total_due": total_due,
             "earliest_due_date": earliest_due_date,
-            "surcharge_amount": surcharge_amount,
-            "discount_amount": discount_amount,
+            "surcharge_amount": display_currency.round(surcharge_amount),
+            "discount_amount": display_currency.round(discount_amount),
             "payment_method": payment_method,
-            "total_amount": total_amount,
+            "total_amount": display_currency.round(total_amount),
             "partner_banks": partner_banks,
             "partner_bank": partner_bank_default,
             "show_select_bank": len(partner_banks) > 1,
@@ -433,33 +428,35 @@ class PaymentController(CustomerPortal):
         currency = display_currency or company.currency_id
         partner_id = request.env.user.partner_id.id
         currency_id = currency.id
-        base_total_amount = sum(
-            -inv.amount_residual
-            if inv.move_type == "out_refund"
-            else inv.amount_residual
-            for inv in invoices
-        )
-        if payment_method == "credit_card":
-            total_amount = base_total_amount
+        surcharge_percent = self._get_surcharge_percent()
+        discount_percent = self._get_plaid_discount_percent()
+        surcharge_amount = 0.0
+        discount_amount = 0.0
+        base_total_amount = 0.0
+        for inv in invoices:
+            if float_is_zero(inv.amount_residual, precision_digits=2):
+                return request.render("payment.pay", {"amount": 0})
 
-            surcharge_percent = self._get_surcharge_percent()
-            surcharge_amount = 0.0
-
-            if surcharge_percent:
-                surcharge_amount = currency.round(
-                    base_total_amount * surcharge_percent / 100
-                )
-                total_amount += surcharge_amount
-
-            access_token = payment_utils.generate_access_token(
-                partner_id, total_amount, currency_id
+            amount_residual = (
+                -inv.amount_residual
+                if inv.move_type == "out_refund"
+                else inv.amount_residual
             )
-
+            base_total_amount += amount_residual
+            surcharge_amount += amount_residual * surcharge_percent / 100
+            discount_amount += amount_residual * discount_percent / 100
+        total_amount = base_total_amount
+        if payment_method == "credit_card":
+            if surcharge_percent:
+                total_amount += surcharge_amount
+            access_token = payment_utils.generate_access_token(
+                partner_id, currency.round(total_amount), currency_id
+            )
             query_params = {
-                "amount": total_amount,
+                "amount": currency.round(total_amount),
                 "access_token": access_token,
-                "surcharge_amount": surcharge_amount,
-                "base_total_amount": base_total_amount,
+                "surcharge_amount": currency.round(surcharge_amount),
+                "base_total_amount": currency.round(base_total_amount),
                 "partner_id": partner_id,
                 "currency_id": currency_id,
                 "invoice": invoice_ids,
@@ -470,53 +467,34 @@ class PaymentController(CustomerPortal):
 
         partner_bank_id = kw.get("partner_bank_id")
 
-        plaid_discount_percent = self._get_plaid_discount_percent()
-
-        payments_vals = request.env["account.payment"].make_payment_values(
-            invoices, plaid_discount_percent, partner_bank_id
-        )
-
-        if payments_vals:
-            discount_account = company.discount_account_id
-            discount_amount = display_currency.round(
-                base_total_amount * plaid_discount_percent / 100
+        if discount_percent > 0.0 and discount_amount > 0.0:
+            self._distribute_discount_amount(
+                invoices, discount_amount, discount_percent
             )
-            if discount_account and discount_amount > 0:
-                for invoice in invoices:
-                    existing_discount_line = invoice.invoice_line_ids.filtered(
-                        lambda l: "Discount" in l.name
-                        and l.account_id == discount_account
-                    )
-                    if existing_discount_line:
-                        continue
 
-                    discount_share = invoice.amount_residual / base_total_amount
-                    line_amount = round(
-                        discount_amount * discount_share, currency.decimal_places
-                    )
+        for invoice in invoices:
+            payment_vals = invoice.prepare_payment_register_vals(partner_bank_id)
+            if not payment_vals:
+                return request.redirect("/my/invoices")
 
-                    invoice.write(
-                        {
-                            "invoice_line_ids": [
-                                Command.create(
-                                    {
-                                        "name": _(
-                                            "%.4g%% Bank Transfer Discount"
-                                            % round(plaid_discount_percent, 4)
-                                        ),
-                                        "quantity": 1.0,
-                                        "price_unit": -line_amount,
-                                        "account_id": discount_account.id,
-                                        "tax_ids": [Command.clear()],
-                                    }
-                                )
-                            ]
-                        }
-                    )
-            payment = request.env["account.payment"].sudo().create(payments_vals)
-            payment.action_post()
-        else:
-            return request.redirect("/my/invoices")
+            register_payment = (
+                request.env["account.payment.register"]
+                .with_context(
+                    active_model="account.move",
+                    active_ids=[invoice.id],
+                )
+                .sudo()
+                .create(payment_vals)
+            )
+
+            is_success = register_payment.with_context(
+                dont_redirect_to_payments=True,
+                force_partner_bank_id=partner_bank_id,
+            ).action_create_payments()
+            if is_success:
+                _logger.info(f"Create successful payment for invoice: '{invoice.name}'")
+            else:
+                _logger.info(f"Create failed payment for invoice: '{invoice.name}'")
 
         return request.redirect("/payment-success")
 
@@ -550,6 +528,48 @@ class PaymentController(CustomerPortal):
             .get_param("account_banking_ach_direct_debit_portal.plaid_discount")
         )
         return self._cast_as_float(plaid_discount) if plaid_discount else 0.0
+
+    def _distribute_discount_amount(
+        self, invoices_sudo, total_discount_amount, discount_percent
+    ):
+        if not invoices_sudo or total_discount_amount <= 0:
+            return
+
+        # Calculate base amounts for each invoice
+        invoice_amounts = []
+        total_base_amount = 0.0
+
+        for invoice in invoices_sudo:
+            amount_residual = (
+                -invoice.amount_residual
+                if invoice.move_type == "out_refund"
+                else invoice.amount_residual
+            )
+            invoice_amounts.append(amount_residual)
+            total_base_amount += amount_residual
+
+        # Distribute discount proportionally
+        distributed_amount = 0.0
+        currency = invoices_sudo[0].currency_id
+
+        for i, invoice in enumerate(invoices_sudo):
+            if i == len(invoices_sudo) - 1:
+                # Last invoice gets the remainder to ensure total matches exactly
+                invoice_discount = total_discount_amount - distributed_amount
+            else:
+                # Calculate proportional amount
+                if total_base_amount > 0:
+                    proportion = invoice_amounts[i] / total_base_amount
+                    invoice_discount = currency.round(
+                        total_discount_amount * proportion
+                    )
+                else:
+                    invoice_discount = 0.0
+
+            if invoice_discount > 0:
+                invoice.add_discount_line(discount_percent, invoice_discount)
+
+            distributed_amount += invoice_discount
 
 
 class PaymentPortal(payment_portal.PaymentPortal):
@@ -604,7 +624,6 @@ class PaymentPortal(payment_portal.PaymentPortal):
         self,
         *args,
         invoices=None,
-        base_total_amount=None,
         surcharge_amount=None,
         custom_create_values=None,
         **kwargs,
@@ -613,50 +632,55 @@ class PaymentPortal(payment_portal.PaymentPortal):
             if custom_create_values is None:
                 custom_create_values = {}
             custom_create_values["invoice_ids"] = [Command.set(invoices)]
-            base_total_amount, surcharge_amount = tuple(
-                map(
-                    self._cast_as_float,
-                    (
-                        base_total_amount if base_total_amount else 0.0,
-                        surcharge_amount if surcharge_amount else 0.0,
-                    ),
-                )
-            )
-            if surcharge_amount and not float_is_zero(
-                surcharge_amount, precision_digits=2
-            ):
-                company = request.env.user.partner_id.company_id
-                surcharge_account = company.surcharge_account_id
+            surcharge_amount = self._cast_as_float(surcharge_amount) or 0.0
+            surcharge_percent = self._get_surcharge_percent()
+            if surcharge_percent > 0.0 and surcharge_amount > 0.0:
                 invoices_sudo = request.env["account.move"].sudo().browse(invoices)
-                percent = self._get_surcharge_percent()
-                for invoice in invoices_sudo:
-                    existing_surcharge_line = invoice.invoice_line_ids.filtered(
-                        lambda l: "Surcharge" in l.name
-                        and l.account_id == surcharge_account
-                    )
-                    if existing_surcharge_line:
-                        continue
-
-                    surcharge_share = invoice.amount_residual / base_total_amount
-                    line_amount = surcharge_amount * surcharge_share
-                    currency = invoice.currency_id or company.currency_id
-                    invoice.write(
-                        {
-                            "invoice_line_ids": [
-                                Command.create(
-                                    {
-                                        "name": _(
-                                            "%.4g%% Credit Card Surcharge" % percent
-                                        ),
-                                        "quantity": 1,
-                                        "price_unit": currency.round(line_amount),
-                                        "account_id": company.surcharge_account_id.id,
-                                        "tax_ids": [Command.clear()],
-                                    }
-                                )
-                            ]
-                        }
-                    )
+                self._distribute_surcharge_amount(
+                    invoices_sudo, surcharge_amount, surcharge_percent
+                )
         return super()._create_transaction(
             *args, custom_create_values=custom_create_values, **kwargs
         )
+
+    def _distribute_surcharge_amount(
+        self, invoices_sudo, total_surcharge_amount, surcharge_percent
+    ):
+        if not invoices_sudo or total_surcharge_amount <= 0:
+            return
+
+        # Calculate base amounts for each invoice
+        invoice_amounts = []
+        total_base_amount = 0.0
+
+        for invoice in invoices_sudo:
+            amount_residual = (
+                -invoice.amount_residual
+                if invoice.move_type == "out_refund"
+                else invoice.amount_residual
+            )
+            invoice_amounts.append(amount_residual)
+            total_base_amount += amount_residual
+
+        # Distribute surcharge proportionally
+        distributed_amount = 0.0
+        currency = invoices_sudo[0].currency_id
+
+        for i, invoice in enumerate(invoices_sudo):
+            if i == len(invoices_sudo) - 1:
+                # Last invoice gets the remainder to ensure total matches exactly
+                invoice_surcharge = total_surcharge_amount - distributed_amount
+            else:
+                # Calculate proportional amount
+                if total_base_amount > 0:
+                    proportion = invoice_amounts[i] / total_base_amount
+                    invoice_surcharge = currency.round(
+                        total_surcharge_amount * proportion
+                    )
+                else:
+                    invoice_surcharge = 0.0
+
+            if invoice_surcharge > 0:
+                invoice.add_surcharge_line(surcharge_percent, invoice_surcharge)
+
+            distributed_amount += invoice_surcharge

--- a/account_banking_ach_direct_debit_portal/controllers/payment.py
+++ b/account_banking_ach_direct_debit_portal/controllers/payment.py
@@ -6,7 +6,7 @@ from odoo import _, fields, http
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.http import request
-from odoo.tools import float_repr
+from odoo.tools import float_is_zero, float_repr
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.controllers import portal as payment_portal
@@ -428,21 +428,18 @@ class PaymentController(CustomerPortal):
             raise ValidationError(_("The provided parameters are invalid."))
 
         payment_method = kw.get("payment_method", "bank_account")
-
+        display_currency = invoices[0].currency_id if invoices else None
+        company = request.env.user.partner_id.company_id
+        currency = display_currency or company.currency_id
+        partner_id = request.env.user.partner_id.id
+        currency_id = currency.id
+        base_total_amount = sum(
+            -inv.amount_residual
+            if inv.move_type == "out_refund"
+            else inv.amount_residual
+            for inv in invoices
+        )
         if payment_method == "credit_card":
-            display_currency = invoices[0].currency_id if invoices else None
-            company = request.env.user.partner_id.company_id
-            currency = display_currency or company.currency_id
-            partner_id = request.env.user.partner_id.id
-            currency_id = currency.id
-
-            base_total_amount = sum(
-                -inv.amount_residual
-                if inv.move_type == "out_refund"
-                else inv.amount_residual
-                for inv in invoices
-            )
-
             total_amount = base_total_amount
 
             surcharge_percent = self._get_surcharge_percent()
@@ -480,6 +477,42 @@ class PaymentController(CustomerPortal):
         )
 
         if payments_vals:
+            discount_account = company.discount_account_id
+            discount_amount = display_currency.round(
+                base_total_amount * plaid_discount_percent / 100
+            )
+            if discount_account and discount_amount > 0:
+                for invoice in invoices:
+                    existing_discount_line = invoice.invoice_line_ids.filtered(
+                        lambda l: "Discount" in l.name
+                        and l.account_id == discount_account
+                    )
+                    if existing_discount_line:
+                        continue
+
+                    discount_share = invoice.amount_residual / base_total_amount
+                    line_amount = round(
+                        discount_amount * discount_share, currency.decimal_places
+                    )
+
+                    invoice.write(
+                        {
+                            "invoice_line_ids": [
+                                Command.create(
+                                    {
+                                        "name": _(
+                                            "%.4g%% Bank Transfer Discount"
+                                            % round(plaid_discount_percent, 4)
+                                        ),
+                                        "quantity": 1.0,
+                                        "price_unit": -line_amount,
+                                        "account_id": discount_account.id,
+                                        "tax_ids": [Command.clear()],
+                                    }
+                                )
+                            ]
+                        }
+                    )
             payment = request.env["account.payment"].sudo().create(payments_vals)
             payment.action_post()
         else:
@@ -568,12 +601,62 @@ class PaymentPortal(payment_portal.PaymentPortal):
         return rendering_context_values
 
     def _create_transaction(
-        self, *args, invoices=None, custom_create_values=None, **kwargs
+        self,
+        *args,
+        invoices=None,
+        base_total_amount=None,
+        surcharge_amount=None,
+        custom_create_values=None,
+        **kwargs,
     ):
         if invoices:
             if custom_create_values is None:
                 custom_create_values = {}
             custom_create_values["invoice_ids"] = [Command.set(invoices)]
+            base_total_amount, surcharge_amount = tuple(
+                map(
+                    self._cast_as_float,
+                    (
+                        base_total_amount if base_total_amount else 0.0,
+                        surcharge_amount if surcharge_amount else 0.0,
+                    ),
+                )
+            )
+            if surcharge_amount and not float_is_zero(
+                surcharge_amount, precision_digits=2
+            ):
+                company = request.env.user.partner_id.company_id
+                surcharge_account = company.surcharge_account_id
+                invoices_sudo = request.env["account.move"].sudo().browse(invoices)
+                percent = self._get_surcharge_percent()
+                for invoice in invoices_sudo:
+                    existing_surcharge_line = invoice.invoice_line_ids.filtered(
+                        lambda l: "Surcharge" in l.name
+                        and l.account_id == surcharge_account
+                    )
+                    if existing_surcharge_line:
+                        continue
+
+                    surcharge_share = invoice.amount_residual / base_total_amount
+                    line_amount = surcharge_amount * surcharge_share
+                    currency = invoice.currency_id or company.currency_id
+                    invoice.write(
+                        {
+                            "invoice_line_ids": [
+                                Command.create(
+                                    {
+                                        "name": _(
+                                            "%.4g%% Credit Card Surcharge" % percent
+                                        ),
+                                        "quantity": 1,
+                                        "price_unit": currency.round(line_amount),
+                                        "account_id": company.surcharge_account_id.id,
+                                        "tax_ids": [Command.clear()],
+                                    }
+                                )
+                            ]
+                        }
+                    )
         return super()._create_transaction(
             *args, custom_create_values=custom_create_values, **kwargs
         )

--- a/account_banking_ach_direct_debit_portal/models/__init__.py
+++ b/account_banking_ach_direct_debit_portal/models/__init__.py
@@ -4,3 +4,4 @@ from . import res_config_settings
 from . import res_partner_bank
 from . import res_partner
 from . import res_user
+from . import res_company

--- a/account_banking_ach_direct_debit_portal/models/__init__.py
+++ b/account_banking_ach_direct_debit_portal/models/__init__.py
@@ -5,3 +5,4 @@ from . import res_partner_bank
 from . import res_partner
 from . import res_user
 from . import res_company
+from . import account_move

--- a/account_banking_ach_direct_debit_portal/models/account_move.py
+++ b/account_banking_ach_direct_debit_portal/models/account_move.py
@@ -1,0 +1,118 @@
+from odoo import Command, _, models
+from odoo.tools import float_is_zero
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def prepare_payment_register_vals(self, partner_bank_id=None):
+        self.ensure_one()
+        bank_journal = (
+            self.env["account.journal"]
+            .sudo()
+            .search(
+                [
+                    ("company_id", "=", self.company_id.id),
+                    ("type", "=", "bank"),
+                ],
+                limit=1,
+            )
+        )
+
+        payment_method_line = bank_journal._get_available_payment_method_lines(
+            "inbound"
+        ).filtered(lambda l: l.code == "ACH-In")
+        if not payment_method_line:
+            return {}
+
+        vals = {
+            "group_payment": False,
+            "journal_id": bank_journal.id,
+            "payment_method_line_id": payment_method_line.id,
+        }
+        if partner_bank_id:
+            vals["partner_bank_id"] = partner_bank_id
+
+        return vals
+
+    def add_discount_line(self, discount_percent, discount_amount=None):
+        self.ensure_one()
+        discount_account = self._get_discount_account()
+        if not discount_account:
+            return
+
+        if discount_amount is None:
+            discount_amount = self.currency_id.round(
+                self.amount_residual * discount_percent / 100
+            )
+
+        if float_is_zero(discount_amount, precision_rounding=self.currency_id.rounding):
+            return
+
+        self.sudo().write(
+            {
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": _(
+                                "%.4g%% Bank Transfer Discount"
+                                % round(discount_percent, 4)
+                            ),
+                            "quantity": 1.0,
+                            "price_unit": -discount_amount,
+                            "account_id": discount_account.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ]
+            }
+        )
+
+    def add_surcharge_line(self, surcharge_percent, surcharge_amount=None):
+        self.ensure_one()
+        surcharge_account = self._get_surcharge_account()
+        if not surcharge_account:
+            return
+
+        # Use provided amount or calculate from percent
+        if surcharge_amount is None:
+            surcharge_amount = self.currency_id.round(
+                self.amount_residual * surcharge_percent / 100
+            )
+
+        if float_is_zero(
+            surcharge_amount, precision_rounding=self.currency_id.rounding
+        ):
+            return
+
+        self.write(
+            {
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": _(
+                                "%.4g%% Credit Card Surcharge" % surcharge_percent
+                            ),
+                            "quantity": 1,
+                            "price_unit": surcharge_amount,
+                            "account_id": surcharge_account.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ]
+            }
+        )
+
+    def _get_discount_account(self):
+        self.ensure_one()
+        return (
+            self.env.company.discount_account_id
+            or self.company_id._get_default_surcharge_discount_account()
+        )
+
+    def _get_surcharge_account(self):
+        self.ensure_one()
+        return (
+            self.env.company.surcharge_account_id
+            or self.company_id._get_default_surcharge_discount_account()
+        )

--- a/account_banking_ach_direct_debit_portal/models/account_payment.py
+++ b/account_banking_ach_direct_debit_portal/models/account_payment.py
@@ -87,7 +87,7 @@ class AccountPayment(models.Model):
             return 0
 
     def _process_autopay_partners(self, partners, today):
-        plaid_discount_percent = self._get_plaid_discount_percent()
+        discount_percent = self._get_plaid_discount_percent()
 
         mail_template = self.env.ref(
             "account_banking_ach_direct_debit_portal.mail_template_autopay_created",
@@ -95,6 +95,11 @@ class AccountPayment(models.Model):
         )
 
         for partner in partners:
+            partner_bank = partner.bank_ids.filtered("default")[:1]
+
+            if not partner_bank:
+                continue
+
             invoices = self.env["account.move"].search(
                 [
                     ("partner_id", "=", partner.id),
@@ -102,114 +107,70 @@ class AccountPayment(models.Model):
                     ("invoice_date_due", "<=", today),
                     ("state", "=", "posted"),
                     ("payment_state", "!=", "paid"),
+                    ("amount_residual", ">", 0.0),
                 ]
             )
-            if not invoices:
-                continue
-
-            partner_bank = self.env["res.partner.bank"].search(
-                [
-                    ("partner_id", "=", partner.id),
-                    ("default", "=", True),
-                ],
-                limit=1,
+            invoices_to_process = invoices.filtered(
+                lambda i: not i._get_reconciled_payments()
             )
-
-            if not partner_bank:
+            if not invoices_to_process:
                 continue
 
-            valid_invoices = []
-            for invoice in invoices:
-                invoice_refs = list(filter(None, [invoice.ref, invoice.name]))
+            if discount_percent > 0.0:
+                # Calculate total discount amount
+                total_discount_amount = 0.0
+                for invoice in invoices_to_process:
+                    amount_residual = (
+                        -invoice.amount_residual
+                        if invoice.move_type == "out_refund"
+                        else invoice.amount_residual
+                    )
+                    total_discount_amount += amount_residual * discount_percent / 100
 
-                existing_payment = self.env["account.payment"].search(
-                    [
-                        ("ref", "in", invoice_refs),
-                        ("state", "!=", "cancel"),
-                    ],
-                    limit=1,
+                # Round total discount and distribute proportionally
+                if total_discount_amount > 0:
+                    currency = invoices_to_process[0].currency_id
+                    total_discount_amount = currency.round(total_discount_amount)
+                    self._distribute_discount_amount_autopay(
+                        invoices_to_process, total_discount_amount, discount_percent
+                    )
+
+            for invoice in invoices_to_process:
+                payment_vals = invoice.prepare_payment_register_vals(partner_bank.id)
+                register_payment = (
+                    self.env["account.payment.register"]
+                    .with_context(
+                        active_model="account.move",
+                        active_ids=[invoice.id],
+                    )
+                    .sudo()
+                    .create(payment_vals)
                 )
+                is_success = register_payment.with_context(
+                    dont_redirect_to_payments=True,
+                    force_partner_bank_id=partner_bank.id,
+                ).action_create_payments()
 
-                if not existing_payment:
-                    valid_invoices.append(invoice)
+                if is_success:
+                    _logger.info(
+                        f"Create successful payment for invoice: '{invoice.name}'"
+                    )
+                else:
+                    _logger.info(f"Create failed payment for invoice: '{invoice.name}'")
 
-            if not valid_invoices:
-                continue
-
-            payments_vals = self.make_payment_values(
-                valid_invoices, plaid_discount_percent, partner_bank.id
-            )
-
-            if not payments_vals:
-                continue
-
-            payment = self.env["account.payment"].create(payments_vals)
-            payment.action_post()
-
-            if mail_template and payments_vals:
-                currency_obj = self.env["res.currency"].browse(
-                    list({val["currency_id"] for val in payments_vals})
-                )
-                currency_map = {c.id: c for c in currency_obj}
-
+            if mail_template and invoices_to_process:
                 ctx = {
                     "invoice_lines": [
                         {
-                            "name": val["ref"],
-                            "amount": val["amount"],
-                            "currency": currency_map[val["currency_id"]].name,
+                            "name": invoice.ref or invoice.name,
+                            "amount": invoice.amount_total_signed,
+                            "currency": invoice.currency_id.name,
                         }
-                        for val in payments_vals
+                        for invoice in invoices_to_process
                     ],
                     "today": fields.Date.to_string(today),
                 }
                 mail_template.with_context(**ctx).send_mail(partner.id, force_send=True)
-
-    @api.model
-    def make_payment_values(self, invoices, discount_percent, partner_bank_id):
-        payments_vals = []
-
-        payment_date = fields.Date.today()
-
-        for invoice in invoices:
-            bank_journal = (
-                self.env["account.journal"]
-                .sudo()
-                .search(
-                    [
-                        ("company_id", "=", invoice.company_id.id),
-                        ("type", "=", "bank"),
-                    ],
-                    limit=1,
-                )
-            )
-
-            payment_method_line = bank_journal._get_available_payment_method_lines(
-                "inbound"
-            ).filtered(lambda l: l.code == "ACH-In")
-            if not payment_method_line:
-                continue
-
-            amount = invoice.amount_residual
-            discount_amount = invoice.currency_id.round(amount * discount_percent / 100)
-            amount -= discount_amount
-
-            payments_vals.append(
-                {
-                    "payment_type": "inbound",
-                    "partner_type": "customer",
-                    "partner_id": invoice.partner_id.id,
-                    "amount": -amount if invoice.move_type == "out_refund" else amount,
-                    "currency_id": invoice.currency_id.id,
-                    "date": payment_date,
-                    "journal_id": bank_journal.id,
-                    "payment_method_line_id": payment_method_line.id,
-                    "ref": invoice.ref or invoice.name,
-                    "partner_bank_id": partner_bank_id,
-                }
-            )
-
-        return payments_vals
 
     def _process_autopay_reminders(self, date, autopay):
         plaid_discount_percent = self._get_plaid_discount_percent()
@@ -228,6 +189,7 @@ class AccountPayment(models.Model):
                 ("state", "=", "posted"),
                 ("payment_state", "!=", "paid"),
                 ("partner_id.autopay", "=", autopay),
+                ("amount_residual", ">", 0.0),
             ]
         )
 
@@ -238,17 +200,7 @@ class AccountPayment(models.Model):
             invoice_map = defaultdict(lambda: 0.0)
 
             for invoice in partner_invoices:
-                invoice_refs = list(filter(None, [invoice.ref, invoice.name]))
-
-                existing_payment = self.env["account.payment"].search(
-                    [
-                        ("ref", "in", invoice_refs),
-                        ("state", "!=", "cancel"),
-                    ],
-                    limit=1,
-                )
-
-                if existing_payment:
+                if invoice._get_reconciled_payments():
                     continue
 
                 amount = invoice.amount_residual
@@ -271,3 +223,45 @@ class AccountPayment(models.Model):
                 }
 
                 mail_template.with_context(**ctx).send_mail(partner.id, force_send=True)
+
+    def _distribute_discount_amount_autopay(
+        self, invoices_sudo, total_discount_amount, discount_percent
+    ):
+        if not invoices_sudo or total_discount_amount <= 0:
+            return
+
+        # Calculate base amounts for each invoice
+        invoice_amounts = []
+        total_base_amount = 0.0
+
+        for invoice in invoices_sudo:
+            amount_residual = (
+                -invoice.amount_residual
+                if invoice.move_type == "out_refund"
+                else invoice.amount_residual
+            )
+            invoice_amounts.append(amount_residual)
+            total_base_amount += amount_residual
+
+        # Distribute discount proportionally
+        distributed_amount = 0.0
+        currency = invoices_sudo[0].currency_id
+
+        for i, invoice in enumerate(invoices_sudo):
+            if i == len(invoices_sudo) - 1:
+                # Last invoice gets the remainder to ensure total matches exactly
+                invoice_discount = total_discount_amount - distributed_amount
+            else:
+                # Calculate proportional amount
+                if total_base_amount > 0:
+                    proportion = invoice_amounts[i] / total_base_amount
+                    invoice_discount = currency.round(
+                        total_discount_amount * proportion
+                    )
+                else:
+                    invoice_discount = 0.0
+
+            if invoice_discount > 0:
+                invoice.add_discount_line(discount_percent, invoice_discount)
+
+            distributed_amount += invoice_discount

--- a/account_banking_ach_direct_debit_portal/models/res_company.py
+++ b/account_banking_ach_direct_debit_portal/models/res_company.py
@@ -1,0 +1,25 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    surcharge_account_id = fields.Many2one(
+        "account.account",
+        string="Surcharge Account",
+        help="Account to use for credit card surcharges.",
+        default=lambda self: self.env.company._get_default_surcharge_discount_account(),
+    )
+    discount_account_id = fields.Many2one(
+        "account.account",
+        string="Discount Account",
+        default=lambda self: self.env.company._get_default_surcharge_discount_account(),
+    )
+
+    def _get_default_surcharge_discount_account(self):
+        invoice_journal = self.env["account.journal"].search(
+            [("type", "=", "sale"), ("company_id", "=", self.id)], limit=1
+        )
+        if invoice_journal and invoice_journal.default_account_id:
+            return invoice_journal.default_account_id.id
+        return False

--- a/account_banking_ach_direct_debit_portal/models/res_config_settings.py
+++ b/account_banking_ach_direct_debit_portal/models/res_config_settings.py
@@ -1,5 +1,7 @@
 from odoo import fields, models
 
+from odoo.addons.account.models.product import ACCOUNT_DOMAIN
+
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
@@ -35,7 +37,22 @@ class ResConfigSettings(models.TransientModel):
         help="Surcharge percentage to apply "
         "when customers pay with a credit card on the portal.",
     )
-
+    surcharge_account_id = fields.Many2one(
+        "account.account",
+        string="Surcharge Account",
+        domain=ACCOUNT_DOMAIN,
+        help="Account to use for credit card surcharges.",
+        related="company_id.surcharge_account_id",
+        readonly=False,
+    )
+    discount_account_id = fields.Many2one(
+        "account.account",
+        string="Discount Account",
+        domain=ACCOUNT_DOMAIN,
+        help="Account to use for plaid discount.",
+        related="company_id.discount_account_id",
+        readonly=False,
+    )
     plaid_discount = fields.Float(
         string="Plaid Discount (%)",
         config_parameter="account_banking_ach_direct_debit_portal.plaid_discount",

--- a/account_banking_ach_direct_debit_portal/static/src/js/payment_form.js
+++ b/account_banking_ach_direct_debit_portal/static/src/js/payment_form.js
@@ -16,9 +16,6 @@ odoo.define("account_banking_ach_direct_debit_portal.payment_form", (require) =>
                 surcharge_amount: parseFloat(this.txContext.surchargeAmount)
                     ? this.txContext.surchargeAmount
                     : 0.0,
-                base_total_amount: parseFloat(this.txContext.baseTotalAmount)
-                    ? this.txContext.baseTotalAmount
-                    : 0.0,
             };
         },
     };

--- a/account_banking_ach_direct_debit_portal/static/src/js/payment_form.js
+++ b/account_banking_ach_direct_debit_portal/static/src/js/payment_form.js
@@ -13,6 +13,12 @@ odoo.define("account_banking_ach_direct_debit_portal.payment_form", (require) =>
                 invoices: Array.isArray(this.txContext.invoices)
                     ? this.txContext.invoices
                     : [],
+                surcharge_amount: parseFloat(this.txContext.surchargeAmount)
+                    ? this.txContext.surchargeAmount
+                    : 0.0,
+                base_total_amount: parseFloat(this.txContext.baseTotalAmount)
+                    ? this.txContext.baseTotalAmount
+                    : 0.0,
             };
         },
     };

--- a/account_banking_ach_direct_debit_portal/views/payment_checkout_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/payment_checkout_templates.xml
@@ -22,12 +22,16 @@
     <template id="payment_checkout_inherit_multi" inherit_id="payment.checkout">
         <xpath expr="//form[@name='o_payment_checkout']" position="attributes">
             <attribute name="t-att-data-invoices">invoices</attribute>
+            <attribute name="t-att-data-surcharge-amount">surcharge_amount</attribute>
+            <attribute name="t-att-data-base-total-amount">base_total_amount</attribute>
         </xpath>
     </template>
 
     <template id="payment_manage_inherit_multi" inherit_id="payment.manage">
         <xpath expr="//form[@name='o_payment_manage']" position="attributes">
             <attribute name="t-att-data-invoices">invoices</attribute>
+            <attribute name="t-att-data-surcharge-amount">surcharge_amount</attribute>
+            <attribute name="t-att-data-base-total-amount">base_total_amount</attribute>
         </xpath>
     </template>
 

--- a/account_banking_ach_direct_debit_portal/views/payment_checkout_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/payment_checkout_templates.xml
@@ -23,7 +23,6 @@
         <xpath expr="//form[@name='o_payment_checkout']" position="attributes">
             <attribute name="t-att-data-invoices">invoices</attribute>
             <attribute name="t-att-data-surcharge-amount">surcharge_amount</attribute>
-            <attribute name="t-att-data-base-total-amount">base_total_amount</attribute>
         </xpath>
     </template>
 
@@ -31,7 +30,6 @@
         <xpath expr="//form[@name='o_payment_manage']" position="attributes">
             <attribute name="t-att-data-invoices">invoices</attribute>
             <attribute name="t-att-data-surcharge-amount">surcharge_amount</attribute>
-            <attribute name="t-att-data-base-total-amount">base_total_amount</attribute>
         </xpath>
     </template>
 

--- a/account_banking_ach_direct_debit_portal/views/payment_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/payment_templates.xml
@@ -643,7 +643,10 @@
                                         t-esc="earliest_due_date"
                                     />
                                 </div>
-                                <div t-if="discount_amount" class="mb-2 row">
+                                <div
+                                    t-if="discount_amount and payment_method == 'bank_account'"
+                                    class="mb-2 row"
+                                >
                                     <label
                                         class="col-sm-4 fw-bold"
                                     >Discount amount</label>
@@ -654,7 +657,10 @@
                                         />
                                     </div>
                                 </div>
-                                <div t-if="surcharge_amount" class="mb-2 row">
+                                <div
+                                    t-if="surcharge_amount and payment_method == 'credit_card'"
+                                    class="mb-2 row"
+                                >
                                     <label
                                         class="col-sm-4 fw-bold"
                                     >Surcharge amount</label>

--- a/account_banking_ach_direct_debit_portal/views/portal_templates.xml
+++ b/account_banking_ach_direct_debit_portal/views/portal_templates.xml
@@ -24,16 +24,20 @@
         </xpath>
     </template>
 
-    <template id="custom_payment_footer_with_back_button" inherit_id="payment.footer">
-        <xpath expr="//div[contains(@class, 'float-end')]" position="before">
-            <button
-                t-if="request.httprequest.path == '/payment/pay'"
-                type="button"
-                class="btn btn-light border btn-lg mb8 mt8"
-                onclick="window.history.back()"
-            >
-                <i class="fa fa-angle-left me-1" />Back
-            </button>
+    <template id="checkout_inherit" inherit_id="payment.checkout">
+        <xpath expr="//form/t[@t-call='{{footer_template_id}}']" position="before">
+            <t t-if="request.httprequest.path == '/payment/pay'">
+                <div class="float-start mt-2">
+                    <button
+                        t-if="request.httprequest.path == '/payment/pay'"
+                        type="button"
+                        class="btn btn-light border btn-lg mb8 mt8"
+                        onclick="window.history.back()"
+                    >
+                        <i class="fa fa-angle-left me-1" />Back
+                    </button>
+                </div>
+            </t>
         </xpath>
     </template>
 </odoo>

--- a/account_banking_ach_direct_debit_portal/views/res_config_settings.xml
+++ b/account_banking_ach_direct_debit_portal/views/res_config_settings.xml
@@ -55,7 +55,10 @@
                 </div>
                 <h2>Bank account</h2>
                 <div class="row mt16 o_settings_container" id="plaid_discount_settings">
-                    <div class="col-xs-12 col-md-6 o_setting_box">
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="plaid_discount_settings"
+                    >
                         <div class="o_setting_left_pane" />
                         <div class="o_setting_right_pane">
                             <label for="plaid_discount" />
@@ -63,7 +66,32 @@
                                 Plaid Discount to apply when customers pay with a bank account on the portal.
                             </div>
                             <div class="content-group">
-                                <field name="plaid_discount" />
+                                <div class="mt16">
+                                    <field
+                                        name="plaid_discount"
+                                        class="o_light_label"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="discount_account_id_setting"
+                    >
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label for="discount_account_id" />
+                            <div class="text-muted">
+                                Account to use for plaid discount.
+                            </div>
+                            <div class="content-group">
+                                <div class="mt16">
+                                    <field
+                                        name="discount_account_id"
+                                        class="o_light_label"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -71,9 +99,12 @@
                 <h2>Credit Card</h2>
                 <div
                     class="row mt16 o_settings_container"
-                    id="credit_card_surcharge_settings"
+                    id="credit_card_general_settings"
                 >
-                    <div class="col-xs-12 col-md-6 o_setting_box">
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="credit_card_surcharge_settings"
+                    >
                         <div class="o_setting_left_pane" />
                         <div class="o_setting_right_pane">
                             <label for="credit_card_surcharge" />
@@ -81,7 +112,32 @@
                                 Surcharge percentage to apply when customers pay with a credit card on the portal.
                             </div>
                             <div class="content-group">
-                                <field name="credit_card_surcharge" />
+                                <div class="mt16">
+                                    <field
+                                        name="credit_card_surcharge"
+                                        class="o_light_label"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="col-12 col-lg-6 o_setting_box"
+                        id="surcharge_account_id_setting"
+                    >
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label for="surcharge_account_id" />
+                            <div class="text-muted">
+                                Account to use for credit card surcharges.
+                            </div>
+                            <div class="content-group">
+                                <div class="mt16">
+                                    <field
+                                        name="surcharge_account_id"
+                                        class="o_light_label"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/account_banking_ach_direct_debit_portal/wizard/__init__.py
+++ b/account_banking_ach_direct_debit_portal/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment_register

--- a/account_banking_ach_direct_debit_portal/wizard/account_payment_register.py
+++ b/account_banking_ach_direct_debit_portal/wizard/account_payment_register.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_wizard(
+            batch_result=batch_result
+        )
+        partner_bank_id = self._context.get("force_partner_bank_id")
+        if partner_bank_id:
+            payment_vals["partner_bank_id"] = partner_bank_id
+        return payment_vals
+
+    def _get_batches(self):
+        batch_vals = super()._get_batches()
+        partner_bank_id = self._context.get("force_partner_bank_id")
+        if partner_bank_id:
+            for vals in batch_vals:
+                vals["partner_bank_id"] = partner_bank_id
+        return batch_vals

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+odoo-addon-account_banking_ach_base @ git+https://github.com/OCA/l10n-usa.git@refs/pull/128/head#subdirectory=setup/account_banking_ach_base
+odoo-addon-account_banking_ach_direct_debit @ git+https://github.com/OCA/l10n-usa.git@refs/pull/127/head#subdirectory=setup/account_banking_ach_direct_debit


### PR DESCRIPTION
* **Add two configurable account fields**:

  * *Discount Account*: to record discount amounts.
  * *Surcharge Account*: to record surcharge amounts.

* **Automatic line generation**:
  Whenever a user makes a payment, the corresponding invoice(s) will automatically generate an additional line to track the discount or surcharge amount applied.

* **Value distribution helpers**:
  Introduce utility functions like `_distribute_*_*` to fairly distribute discount/surcharge amounts when rounding differences occur.

* **Example – rounding difference scenario**:
  Suppose there are three invoices:

  * 268.41
  * 223.10
  * 169.05
    **Total:** 660.56
    With a discount rate of **1%**:

  **Total-based calculation**:

  * Total discount = 660.56 × 1% = 6.6056 → rounded to 6.61
  * Final amount after discount = 660.56 − 6.61 = **653.95**

  **Per-invoice calculation**:

  * 268.41 × 1% = 2.6841 → 2.68
  * 223.10 × 1% = 2.2310 → 2.23
  * 169.05 × 1% = 1.6905 → 1.69
  * Total discount = 2.68 + 2.23 + 1.69 = **6.60**
  * Final amount after discount = 660.56 − 6.60 = **653.96**

  This results in a **0.01** difference between the total-based and per-invoice approaches, which the distribution functions are designed to resolve - make sure that the sum of discount/surcharge lines should be rounded up

